### PR TITLE
Fix urlExists to use HTTPS for HTTPS URLs and make feedsession.json o…

### DIFF
--- a/src/lib/feed-archive.ts
+++ b/src/lib/feed-archive.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import { Logger } from '../utils/logger'
 import { chalkBoldLabel, chalkBoldVariable } from '../utils/chalkUtils'
-import { fileExists, loadGitFeedFile, loadLocalFeedFile, writeJsonFile } from '../utils/config';
+import { fileExists, loadGitFeedFile, loadGitFeedSessionFile, loadLocalFeedFile, writeJsonFile } from '../utils/config';
 import { defaultFakerRulesFile, defaultFeedAnalysisFile, defaultFeedApiEndpointFile, defaultFeedInfoFile, defaultFeedRulesFile, defaultFeedSchemasFile, defaultFeedSessionFile } from '../utils/defaults';
 import { getGitEventFeeds, getLocalEventFeeds } from '../utils/listfeeds';
 
@@ -154,8 +154,12 @@ const feedDownload = async (options: ManageFeedClientOptions, optionsSource: any
     writeJsonFile(`${zipPath}/${defaultFeedSchemasFile}`, data);
     data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedRulesFile) : loadLocalFeedFile(feedName, defaultFeedRulesFile);
     writeJsonFile(`${zipPath}/${defaultFeedRulesFile}`, data);
-    data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedSessionFile) : loadLocalFeedFile(feedName, defaultFeedSessionFile);
-    writeJsonFile(`${zipPath}/${defaultFeedSessionFile}`, data);
+    try {
+      data = gitFeed ? await loadGitFeedSessionFile(feedName, defaultFeedSessionFile) : loadLocalFeedFile(feedName, defaultFeedSessionFile);
+      writeJsonFile(`${zipPath}/${defaultFeedSessionFile}`, data);
+    } catch (error: any) {
+      Logger.logWarn(`feed session file not found, skipping...`);
+    }
     data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedSchemasFile) : loadLocalFeedFile(feedName, defaultFeedSchemasFile);
     writeJsonFile(`${zipPath}/${defaultFeedSchemasFile}`, data);
   } else if (info.type === 'restapi_feed') {
@@ -165,8 +169,12 @@ const feedDownload = async (options: ManageFeedClientOptions, optionsSource: any
     writeJsonFile(`${zipPath}/${defaultFeedApiEndpointFile}`, data);
     data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedRulesFile) : loadLocalFeedFile(feedName, defaultFeedRulesFile);
     writeJsonFile(`${zipPath}/${defaultFeedRulesFile}`, data);
-    data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedSessionFile) : loadLocalFeedFile(feedName, defaultFeedSessionFile);
-    writeJsonFile(`${zipPath}/${defaultFeedSessionFile}`, data);
+    try {
+      data = gitFeed ? await loadGitFeedSessionFile(feedName, defaultFeedSessionFile) : loadLocalFeedFile(feedName, defaultFeedSessionFile);
+      writeJsonFile(`${zipPath}/${defaultFeedSessionFile}`, data);
+    } catch (error: any) {
+      Logger.logWarn(`feed session file not found, skipping...`);
+    }
   }
 
   await zlib.archiveFolder(exportPath , options.archiveFile.endsWith('.zip') ? options.archiveFile : options.archiveFile + '.zip').then(function () {

--- a/src/lib/feed-archive.ts
+++ b/src/lib/feed-archive.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import { Logger } from '../utils/logger'
 import { chalkBoldLabel, chalkBoldVariable } from '../utils/chalkUtils'
-import { fileExists, loadGitFeedFile, loadGitFeedSessionFile, loadLocalFeedFile, writeJsonFile } from '../utils/config';
+import { fileExists, loadGitFeedFile, loadGitFeedSessionFile, loadLocalFeedFile, loadLocalFeedSessionFile, writeJsonFile } from '../utils/config';
 import { defaultFakerRulesFile, defaultFeedAnalysisFile, defaultFeedApiEndpointFile, defaultFeedInfoFile, defaultFeedRulesFile, defaultFeedSchemasFile, defaultFeedSessionFile } from '../utils/defaults';
 import { getGitEventFeeds, getLocalEventFeeds } from '../utils/listfeeds';
 
@@ -155,7 +155,7 @@ const feedDownload = async (options: ManageFeedClientOptions, optionsSource: any
     data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedRulesFile) : loadLocalFeedFile(feedName, defaultFeedRulesFile);
     writeJsonFile(`${zipPath}/${defaultFeedRulesFile}`, data);
     try {
-      data = gitFeed ? await loadGitFeedSessionFile(feedName, defaultFeedSessionFile) : loadLocalFeedFile(feedName, defaultFeedSessionFile);
+      data = gitFeed ? await loadGitFeedSessionFile(feedName, defaultFeedSessionFile) : loadLocalFeedSessionFile(feedName, defaultFeedSessionFile);
       writeJsonFile(`${zipPath}/${defaultFeedSessionFile}`, data);
     } catch (error: any) {
       Logger.logWarn(`feed session file not found, skipping...`);
@@ -170,7 +170,7 @@ const feedDownload = async (options: ManageFeedClientOptions, optionsSource: any
     data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedRulesFile) : loadLocalFeedFile(feedName, defaultFeedRulesFile);
     writeJsonFile(`${zipPath}/${defaultFeedRulesFile}`, data);
     try {
-      data = gitFeed ? await loadGitFeedSessionFile(feedName, defaultFeedSessionFile) : loadLocalFeedFile(feedName, defaultFeedSessionFile);
+      data = gitFeed ? await loadGitFeedSessionFile(feedName, defaultFeedSessionFile) : loadLocalFeedSessionFile(feedName, defaultFeedSessionFile);
       writeJsonFile(`${zipPath}/${defaultFeedSessionFile}`, data);
     } catch (error: any) {
       Logger.logWarn(`feed session file not found, skipping...`);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import https from 'https'
 import http from 'http'
 import path from 'path'
 import { Logger } from './logger'
@@ -910,11 +911,12 @@ export const urlExists = async (url:any) => {
 	const valid_url = validURL(url)
 	if (!valid_url) return false
 
-	const { host, pathname } = valid_url
+	const { host, pathname, protocol } = valid_url
 	const opt = { method: 'HEAD', host, path: pathname }
+	const transport = protocol === 'https:' ? https : http
 
 	return new Promise((resolve) => {
-		const req = http.request(opt, (r) =>
+		const req = transport.request(opt, (r) =>
 			resolve(/4\d\d/.test(`${r.statusCode}`) === false),
 		)
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -911,8 +911,15 @@ export const urlExists = async (url:any) => {
 	const valid_url = validURL(url)
 	if (!valid_url) return false
 
-	const { host, pathname, protocol } = valid_url
-	const opt = { method: 'HEAD', host, path: pathname }
+	const { hostname, port, pathname, search, protocol } = valid_url
+	const opt: http.RequestOptions | https.RequestOptions = {
+    method: 'HEAD',
+    hostname,
+    path: `${pathname}${search ?? ''}`,
+  }
+  if (port) {
+    ;(opt as any).port = port
+  }
 	const transport = protocol === 'https:' ? https : http
 
 	return new Promise((resolve) => {


### PR DESCRIPTION
Fix urlExists to use HTTPS for HTTPS URLs and make feedsession.json optional in feed download

The urlExists function used http for all requests, causing URL validation to silently fail on HTTPS URLs (like GitHub raw content). The feed download also hard-exited when feedsession.json was missing, even though it's not present in all community feeds.

