### PR TITLE
Support arm64 arch for MacOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,20 +39,22 @@ jobs:
       - name: Prepare stm archives for different targets
         run: |
           cd release
-          zip -qq -r stm-macos-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos
-          zip -qq -r stm-linux-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-linux
-          zip -qq -r stm-alpine-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-alpine
-          zip -qq -r stm-win-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-win.exe
+          zip -qq -r stm-macos-arm64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos-arm64
+          zip -qq -r stm-macos-x64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos-x64
+          zip -qq -r stm-linux-x64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-linux-x64
+          zip -qq -r stm-alpine-x64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-alpine-x64
+          zip -qq -r stm-win-x64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-win-x64.exe
           cd ..
       
       - name: Publish artifacts to github
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            release/stm-macos-v${{ steps.package-version.outputs.current-version}}.zip
-            release/stm-linux-v${{ steps.package-version.outputs.current-version}}.zip
-            release/stm-alpine-v${{ steps.package-version.outputs.current-version}}.zip
-            release/stm-win-v${{ steps.package-version.outputs.current-version}}.zip
+            release/stm-macos-arm64-v${{ steps.package-version.outputs.current-version}}.zip
+            release/stm-macos-x64-v${{ steps.package-version.outputs.current-version}}.zip
+            release/stm-linux-x64-v${{ steps.package-version.outputs.current-version}}.zip
+            release/stm-alpine-x64-v${{ steps.package-version.outputs.current-version}}.zip
+            release/stm-win-x64-v${{ steps.package-version.outputs.current-version}}.zip
 
       - name: Update Homebrew 
         run: ./scripts/update_homebrew.sh ${{ steps.package-version.outputs.current-version}}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "targets": [
       "node18-linux-x64",
       "node18-macos-x64",
+      "node18-macos-arm64",
       "node18-win-x64",
       "node18-alpine-x64"
     ],

--- a/scripts/update_apt.sh
+++ b/scripts/update_apt.sh
@@ -12,7 +12,7 @@ pkg_version=$1
 git clone https://x-access-token:$GITHUB_TOKEN@github.com/$APT_SERVER
 
 # Prepare for APT update
-reprepro -b apt-stm/ --priority 0 includedeb stm stm-linux_$pkg_version\_amd64.deb
+reprepro -b apt-stm/ --priority 0 includedeb stm stm-linux-x64_$pkg_version\_amd64.deb
 
 # Commit and push changes
 cd apt-stm/

--- a/scripts/update_homebrew.sh
+++ b/scripts/update_homebrew.sh
@@ -10,15 +10,25 @@ FORMULA_NAME="stm"
 git clone https://x-access-token:$GITHUB_TOKEN@github.com/$TAP_NAME
 
 cd homebrew-$FORMULA_NAME
-
+ 
 # Update formula
 pkg_version=$1
+
+# Calculate SHA256 for both archs
+SHA256_X64=$(shasum -a 256 ../release/stm-macos-x64-v$pkg_version.zip | awk '{ print $1 }')
+SHA256_ARM64=$(shasum -a 256 ../release/stm-macos-arm64-v$pkg_version.zip | awk '{ print $1 }')
+
+# Update version
 sed -i "s|url .*|url \"https://github.com/$REPO_NAME/releases/download/v$pkg_version/stm-macos-v$pkg_version.zip\"|" Formula/$FORMULA_NAME.rb
-sed -i "s|sha256 .*|sha256 \"$(shasum -a 256 ../release/stm-macos-v$pkg_version.zip | awk '{ print $1 }')\"|" Formula/$FORMULA_NAME.rb
+# Update SHA256 für x64
+sed -i "/on_intel/,/end/ s|sha256 \".*\"|sha256 \"$SHA256_X64\"|" Formula/$FORMULA_NAME.rb
+# Update SHA256 für arm64
+sed -i "/on_arm/,/end/ s|sha256 \".*\"|sha256 \"$SHA256_ARM64\"|" Formula/$FORMULA_NAME.rb
+
 # Commit and push changes
 git config --global user.email "community@solace.com"
 git config --global user.name "SollyBot"
 git commit -am "Update $FORMULA_NAME to $pkg_version"
 git push
-
+ 
 cd ..


### PR DESCRIPTION
As discussed in issue https://github.com/SolaceLabs/solace-tryme-cli/issues/65, this PR introduces native support for Apple Silicon. This eliminates the "bad CPU type" error. I had to add the architecture classification to every binary. Tested the arm binary locally. Ready for review.
Needs to be merged together with https://github.com/SolaceLabs/homebrew-stm/pull/1