### PR TITLE
refactor: replace var with let and const for variable declarations across multiple files

### DIFF
--- a/public/feed/adminlte.js
+++ b/public/feed/adminlte.js
@@ -1460,7 +1460,7 @@
       this._fixHeight(true);
 
       if (usingDefTab) {
-        var $el = $__default["default"]("" + SELECTOR_TAB_PANE).first(); // eslint-disable-next-line no-console
+        var $el = $__default["default"]("" + SELECTOR_TAB_PANE).first();  
 
         console.log($el);
         var uniqueName = $el.attr('id').replace('panel-', '');

--- a/public/plugins/jquery/jquery.js
+++ b/public/plugins/jquery/jquery.js
@@ -733,7 +733,7 @@ try {
 
 	// Support: Android<4.0
 	// Detect silently failing push.apply
-	// eslint-disable-next-line no-unused-expressions
+	 
 	arr[ preferredDoc.childNodes.length ].nodeType;
 } catch ( e ) {
 	push = { apply: arr.length ?
@@ -1134,7 +1134,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( doc == document || doc.nodeType !== 9 || !doc.documentElement ) {
 		return document;
 	}
@@ -1149,7 +1149,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( preferredDoc != document &&
 		( subWindow = document.defaultView ) && subWindow.top !== subWindow ) {
 
@@ -1494,7 +1494,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		// Support: IE 11+, Edge 17 - 18+
 		// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 		// two documents; shallow comparisons work.
-		// eslint-disable-next-line eqeqeq
+		 
 		compare = ( a.ownerDocument || a ) == ( b.ownerDocument || b ) ?
 			a.compareDocumentPosition( b ) :
 
@@ -1509,7 +1509,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			// eslint-disable-next-line eqeqeq
+			 
 			if ( a == document || a.ownerDocument == preferredDoc &&
 				contains( preferredDoc, a ) ) {
 				return -1;
@@ -1518,7 +1518,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			// eslint-disable-next-line eqeqeq
+			 
 			if ( b == document || b.ownerDocument == preferredDoc &&
 				contains( preferredDoc, b ) ) {
 				return 1;
@@ -1553,10 +1553,10 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			/* eslint-disable eqeqeq */
+			 
 			return a == document ? -1 :
 				b == document ? 1 :
-				/* eslint-enable eqeqeq */
+				 
 				aup ? -1 :
 				bup ? 1 :
 				sortInput ?
@@ -1592,10 +1592,10 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			/* eslint-disable eqeqeq */
+			 
 			ap[ i ] == preferredDoc ? -1 :
 			bp[ i ] == preferredDoc ? 1 :
-			/* eslint-enable eqeqeq */
+			 
 			0;
 	};
 
@@ -1639,7 +1639,7 @@ Sizzle.contains = function( context, elem ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( ( context.ownerDocument || context ) != document ) {
 		setDocument( context );
 	}
@@ -1652,7 +1652,7 @@ Sizzle.attr = function( elem, name ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( ( elem.ownerDocument || elem ) != document ) {
 		setDocument( elem );
 	}
@@ -1898,7 +1898,7 @@ Expr = Sizzle.selectors = {
 
 				result += "";
 
-				/* eslint-disable max-len */
+				 
 
 				return operator === "=" ? result === check :
 					operator === "!=" ? result !== check :
@@ -1908,7 +1908,7 @@ Expr = Sizzle.selectors = {
 					operator === "~=" ? ( " " + result.replace( rwhitespace, " " ) + " " ).indexOf( check ) > -1 :
 					operator === "|=" ? result === check || result.slice( 0, check.length + 1 ) === check + "-" :
 					false;
-				/* eslint-enable max-len */
+				 
 
 			};
 		},
@@ -2197,7 +2197,7 @@ Expr = Sizzle.selectors = {
 			// Accessing this property makes selected-by-default
 			// options in Safari work properly
 			if ( elem.parentNode ) {
-				// eslint-disable-next-line no-unused-expressions
+				 
 				elem.parentNode.selectedIndex;
 			}
 
@@ -2691,7 +2691,7 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 				// Support: IE 11+, Edge 17 - 18+
 				// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 				// two documents; shallow comparisons work.
-				// eslint-disable-next-line eqeqeq
+				 
 				outermostContext = context == document || context || outermost;
 			}
 
@@ -2705,7 +2705,7 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 					// Support: IE 11+, Edge 17 - 18+
 					// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 					// two documents; shallow comparisons work.
-					// eslint-disable-next-line eqeqeq
+					 
 					if ( !context && elem.ownerDocument != document ) {
 						setDocument( elem );
 						xml = !documentIsHTML;
@@ -7469,11 +7469,11 @@ function defaultPrefilter( elem, props, opts ) {
 				showHide( [ elem ], true );
 			}
 
-			/* eslint-disable no-loop-func */
+			 
 
 			anim.done( function() {
 
-				/* eslint-enable no-loop-func */
+				 
 
 				// The final step of a "hide" animation is actually hiding the element
 				if ( !hidden ) {

--- a/public/plugins/jquery/jquery.slim.js
+++ b/public/plugins/jquery/jquery.slim.js
@@ -733,7 +733,7 @@ try {
 
 	// Support: Android<4.0
 	// Detect silently failing push.apply
-	// eslint-disable-next-line no-unused-expressions
+	 
 	arr[ preferredDoc.childNodes.length ].nodeType;
 } catch ( e ) {
 	push = { apply: arr.length ?
@@ -1134,7 +1134,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( doc == document || doc.nodeType !== 9 || !doc.documentElement ) {
 		return document;
 	}
@@ -1149,7 +1149,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( preferredDoc != document &&
 		( subWindow = document.defaultView ) && subWindow.top !== subWindow ) {
 
@@ -1494,7 +1494,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		// Support: IE 11+, Edge 17 - 18+
 		// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 		// two documents; shallow comparisons work.
-		// eslint-disable-next-line eqeqeq
+		 
 		compare = ( a.ownerDocument || a ) == ( b.ownerDocument || b ) ?
 			a.compareDocumentPosition( b ) :
 
@@ -1509,7 +1509,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			// eslint-disable-next-line eqeqeq
+			 
 			if ( a == document || a.ownerDocument == preferredDoc &&
 				contains( preferredDoc, a ) ) {
 				return -1;
@@ -1518,7 +1518,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			// eslint-disable-next-line eqeqeq
+			 
 			if ( b == document || b.ownerDocument == preferredDoc &&
 				contains( preferredDoc, b ) ) {
 				return 1;
@@ -1553,10 +1553,10 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			/* eslint-disable eqeqeq */
+			 
 			return a == document ? -1 :
 				b == document ? 1 :
-				/* eslint-enable eqeqeq */
+				 
 				aup ? -1 :
 				bup ? 1 :
 				sortInput ?
@@ -1592,10 +1592,10 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// Support: IE 11+, Edge 17 - 18+
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
-			/* eslint-disable eqeqeq */
+			 
 			ap[ i ] == preferredDoc ? -1 :
 			bp[ i ] == preferredDoc ? 1 :
-			/* eslint-enable eqeqeq */
+			 
 			0;
 	};
 
@@ -1639,7 +1639,7 @@ Sizzle.contains = function( context, elem ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( ( context.ownerDocument || context ) != document ) {
 		setDocument( context );
 	}
@@ -1652,7 +1652,7 @@ Sizzle.attr = function( elem, name ) {
 	// Support: IE 11+, Edge 17 - 18+
 	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 	// two documents; shallow comparisons work.
-	// eslint-disable-next-line eqeqeq
+	 
 	if ( ( elem.ownerDocument || elem ) != document ) {
 		setDocument( elem );
 	}
@@ -1898,7 +1898,7 @@ Expr = Sizzle.selectors = {
 
 				result += "";
 
-				/* eslint-disable max-len */
+				 
 
 				return operator === "=" ? result === check :
 					operator === "!=" ? result !== check :
@@ -1908,7 +1908,7 @@ Expr = Sizzle.selectors = {
 					operator === "~=" ? ( " " + result.replace( rwhitespace, " " ) + " " ).indexOf( check ) > -1 :
 					operator === "|=" ? result === check || result.slice( 0, check.length + 1 ) === check + "-" :
 					false;
-				/* eslint-enable max-len */
+				 
 
 			};
 		},
@@ -2197,7 +2197,7 @@ Expr = Sizzle.selectors = {
 			// Accessing this property makes selected-by-default
 			// options in Safari work properly
 			if ( elem.parentNode ) {
-				// eslint-disable-next-line no-unused-expressions
+				 
 				elem.parentNode.selectedIndex;
 			}
 
@@ -2691,7 +2691,7 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 				// Support: IE 11+, Edge 17 - 18+
 				// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 				// two documents; shallow comparisons work.
-				// eslint-disable-next-line eqeqeq
+				 
 				outermostContext = context == document || context || outermost;
 			}
 
@@ -2705,7 +2705,7 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 					// Support: IE 11+, Edge 17 - 18+
 					// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 					// two documents; shallow comparisons work.
-					// eslint-disable-next-line eqeqeq
+					 
 					if ( !context && elem.ownerDocument != document ) {
 						setDocument( elem );
 						xml = !documentIsHTML;

--- a/public/scripts/MQTTSolaceClient.js
+++ b/public/scripts/MQTTSolaceClient.js
@@ -1,6 +1,4 @@
-/* eslint-disable no-plusplus */
 /* eslint-disable no-useless-escape */
-/* eslint-disable arrow-body-style */
 /* eslint-disable no-undef */
 class SolaceClient {
   constructor(onConnectionSuccess, onConnectionError, onConnectionLost) {
@@ -13,7 +11,7 @@ class SolaceClient {
     this.onConnectionLost = onConnectionLost;
     this.client = new Paho.MQTT.Client(
       connection.MQTT_HOST,
-      // eslint-disable-next-line radix
+       
       parseInt(connection.MQTT_PORT),
       '/',
       'visualizer');

--- a/public/theme/adminlte.js
+++ b/public/theme/adminlte.js
@@ -1460,7 +1460,7 @@
       this._fixHeight(true);
 
       if (usingDefTab) {
-        var $el = $__default["default"]("" + SELECTOR_TAB_PANE).first(); // eslint-disable-next-line no-console
+        var $el = $__default["default"]("" + SELECTOR_TAB_PANE).first();  
 
         console.log($el);
         var uniqueName = $el.attr('id').replace('panel-', '');

--- a/src/common/aclprofile-client.ts
+++ b/src/common/aclprofile-client.ts
@@ -61,8 +61,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get acl-profile successful`)
-          let result = data.data;
-          var aclProfiles = "";
+          const result = data.data;
+          let aclProfiles = "";
           aclProfiles += `\n${prettyJSON(JSON.stringify(result))}`
           Logger.logDetailedSuccess(`Details of acl-profile ${this.options.aclProfile} on vpn ${this.options.sempVpn}`, aclProfiles)
         }
@@ -93,8 +93,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get acl-profiles list successful`)
-          let result = data.data;
-          var aclProfiles = "";
+          const result = data.data;
+          let aclProfiles = "";
           result.forEach((acl:any) => aclProfiles += `\n${acl.aclProfileName}`)
           Logger.logDetailedSuccess(`${result.length} acl-profile(s) found on vpn ${this.options.sempVpn}`, aclProfiles)
         }

--- a/src/common/clientprofile-client.ts
+++ b/src/common/clientprofile-client.ts
@@ -68,8 +68,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get client-profile successful`)
-          let result = data.data;
-          var clientProfiles = "";
+          const result = data.data;
+          let clientProfiles = "";
           clientProfiles += `\n${prettyJSON(JSON.stringify(result))}`
           Logger.logDetailedSuccess(`Details of client-profile ${this.options.clientProfile} on vpn ${this.options.sempVpn}`, clientProfiles)
         }
@@ -101,8 +101,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get client-profiles list successful`)
-          let result = data.data;
-          var clientProfiles = "";
+          const result = data.data;
+          let clientProfiles = "";
           result.forEach((profile:any) => clientProfiles += `\n${profile.clientProfileName}`)
           Logger.logDetailedSuccess(`${result.length} client profile(s) found on vpn ${this.options.sempVpn}`, clientProfiles)
         }

--- a/src/common/clientusername-client.ts
+++ b/src/common/clientusername-client.ts
@@ -62,8 +62,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get client-username successful`)
-          let result = data.data;
-          var clientUsernames = "";
+          const result = data.data;
+          let clientUsernames = "";
           clientUsernames += `\n${prettyJSON(JSON.stringify(result))}`
           Logger.logDetailedSuccess(`Details of client-username ${this.options.clientUsername} on vpn ${this.options.sempVpn}`, clientUsernames)
         }
@@ -95,8 +95,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get client-usernames list successful`)
-          let result = data.data;
-          var clientUsernames = "";
+          const result = data.data;
+          let clientUsernames = "";
           result.forEach((username:any) => clientUsernames += `\n${username.clientUsername}`)
           Logger.logDetailedSuccess(`${result.length} client username(s) found on vpn ${this.options.sempVpn}`, clientUsernames)
         }

--- a/src/common/feed-publish-client.ts
+++ b/src/common/feed-publish-client.ts
@@ -26,9 +26,9 @@ const deliveryModeMap:Map<string, MessageDeliveryModeType> = new Map<string, Mes
 
 const dateFormatOptions: Intl.DateTimeFormatOptions = {
   hour12: false,
-  hour: '2-digit' as '2-digit',
-  minute: '2-digit' as '2-digit',
-  second: '2-digit' as '2-digit',
+  hour: '2-digit' as const,
+  minute: '2-digit' as const,
+  second: '2-digit' as const,
   fractionalSecondDigits: 3 // Include milliseconds with 3 digits
 };
 
@@ -49,7 +49,7 @@ export class SolaceClient extends VisualizeClient {
     this.options = options;
 
     //Initializing the solace client library
-    let factoryProps = new solace.SolclientFactoryProperties();
+    const factoryProps = new solace.SolclientFactoryProperties();
     factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
     solace.SolclientFactory.init(factoryProps);
     this.options.logLevel && solace.SolclientFactory.setLogLevel(logLevelMap.get(this.options.logLevel.toUpperCase()) as LogLevel);
@@ -170,9 +170,9 @@ export class SolaceClient extends VisualizeClient {
     if (path.indexOf('.') < 0)
       return obj[path];
   
-    let field = path.substring(0, path.indexOf('.'));
-    let fieldName = field.replaceAll('[0]', '');
-    var remaining = path.substring(path.indexOf('.')+1);
+    const field = path.substring(0, path.indexOf('.'));
+    const fieldName = field.replaceAll('[0]', '');
+    const remaining = path.substring(path.indexOf('.')+1);
     return this.getSourceFieldValue(field.includes('[0]') ? obj[fieldName][0] : obj[field], remaining);
   }
 
@@ -186,14 +186,14 @@ export class SolaceClient extends VisualizeClient {
       return quote + content.replace(/ /g, '$') + quote;
     });    
     
-    var props = result.split(' ');
-    var propsMap:any = {};
+    const props = result.split(' ');
+    const propsMap:any = {};
     props.forEach((prop) => {
       const [key, val] = prop.split(':')
       if (key && val) {
-        var _key = key.trim().replace(/\$/g, ' ');
+        let _key = key.trim().replace(/\$/g, ' ');
         _key = _key.replace(/^['"]|['"]$/g, '');
-        var _val = val.trim().replace(/\$/g, ' ');
+        let _val = val.trim().replace(/\$/g, ' ');
         _val = _val.replace(/^['"]|['"]$/g, '');
         propsMap[_key] = _val;
       }
@@ -211,13 +211,13 @@ export class SolaceClient extends VisualizeClient {
       return;
     }
     try {
-      var payloadType = settings.payloadType as string;
+      const payloadType = settings.payloadType as string;
       if (!topicName.startsWith('@STM')) {
         settings.publishConfirmation && settings.deliveryMode === 'PERSISTENT' ?
                   Logger.await(`${chalkEventCounterValue(iter+1)} publishing ${settings.deliveryMode} message with correlation key ${this.pubConfirmationId} [${new Date().toLocaleString('en-US', dateFormatOptions)}]`) :
                   Logger.await(`${chalkEventCounterValue(iter+1)} publishing ${settings.deliveryMode} message [${new Date().toLocaleString('en-US', dateFormatOptions)}]`);
       }
-      let message = solace.SolclientFactory.createMessage();
+      const message = solace.SolclientFactory.createMessage();
       message.setDestination(solace.SolclientFactory.createTopicDestination(topicName));
       settings.httpContentEncoding !== undefined && message.setHttpContentEncoding(settings.httpContentEncoding);
       settings.httpContentType !== undefined && message.setHttpContentType(settings.httpContentType);
@@ -235,7 +235,7 @@ export class SolaceClient extends VisualizeClient {
             if (typeof payload === 'object') {
               message.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, JSON.stringify(payload)));
             } else {
-              var jsonPayload = JSON.parse(payload.toString());
+              const jsonPayload = JSON.parse(payload.toString());
               message.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, JSON.stringify(jsonPayload)));
             }
           } catch (error) {
@@ -288,15 +288,15 @@ export class SolaceClient extends VisualizeClient {
       settings.appMessageType !== undefined && message.setApplicationMessageType(settings.appMessageType);
       settings.replyToTopic !== undefined && message.setReplyTo(solace.SolclientFactory.createTopicDestination(settings.replyToTopic))
       if (this.options.userProperties) {
-        let propertyMap = new solace.SDTMapContainer();
-        let props:Record<string, string | string[]> = this.options.userProperties;
+        const propertyMap = new solace.SDTMapContainer();
+        const props:Record<string, string | string[]> = this.options.userProperties;
         Object.entries(props).forEach((entry) => {
           propertyMap.addField(entry[0], solace.SDTField.create(solace.SDTFieldType.STRING, entry[1]));
         });
         message.setUserPropertyMap(propertyMap);    
       } else if (settings.userProperties) {
-        var userProperties = this.prepareUserPropertiesFromSettings(settings.userProperties);
-        let propertyMap = new solace.SDTMapContainer();
+        const userProperties = this.prepareUserPropertiesFromSettings(settings.userProperties);
+        const propertyMap = new solace.SDTMapContainer();
         Object.entries(userProperties).forEach((entry) => {
           propertyMap.addField(entry[0], solace.SDTField.create(solace.SDTFieldType.STRING, entry[1]));
         });
@@ -307,7 +307,7 @@ export class SolaceClient extends VisualizeClient {
         let propertyMap = message.getUserPropertyMap();
         if (!propertyMap) propertyMap = new solace.SDTMapContainer();
         
-        var pKey2 = 'pkey-' + Date.now() % settings.partitionKeysCount;
+        const pKey2 = 'pkey-' + Date.now() % settings.partitionKeysCount;
         propertyMap.addField("JMSXGroupID", solace.SDTField.create(solace.SDTFieldType.STRING, pKey2));
         message.setUserPropertyMap(propertyMap);    
       } else if (settings.partitionKeysList && settings.partitionKeysList.length) {
@@ -322,15 +322,15 @@ export class SolaceClient extends VisualizeClient {
           settings.partitionKeys = '';
         }
 
-        var fields = settings.partitionKeys.split('|').map((field:string) => field.trim());
+        const fields = settings.partitionKeys.split('|').map((field:string) => field.trim());
         if (fields.length) {
           let propertyMap = message.getUserPropertyMap();
           if (!propertyMap) propertyMap = new solace.SDTMapContainer();
           
-          var values:string[] = [];
+          const values:string[] = [];
           fields.forEach((field:string) => {
             try {
-              let val:string = this.getSourceFieldValue(payload, field);
+              const val:string = this.getSourceFieldValue(payload, field);
               values.push(val);
             } catch (error:any) {
               Logger.logWarn(`failed to get field value for ${field} - ${error.toString()}`)

--- a/src/common/jsonParser.ts
+++ b/src/common/jsonParser.ts
@@ -24,9 +24,9 @@ export class JsonSchemaParser {
 
   parseElement = (schema:any, value:any, pointer:any) => {
     if (!pointer.startsWith('#/__rootSchema/')) return;
-    var tokens = pointer.split('/');
+    const tokens = pointer.split('/');
     if ((tokens.filter((t:string) => t === 'properties')).length > 1) return;
-    var token = tokens.pop();
+    const token = tokens.pop();
     if (token.startsWith('x-ep-')) {
       Logger.info(`Here in CB for x-ep - ${token}`);
       Logger.info(`Schema: ${JSON.stringify(schema)}`);

--- a/src/common/publish-client.ts
+++ b/src/common/publish-client.ts
@@ -25,9 +25,9 @@ const deliveryModeMap:Map<string, MessageDeliveryModeType> = new Map<string, Mes
 
 const dateFormatOptions: Intl.DateTimeFormatOptions = {
   hour12: false,
-  hour: '2-digit' as '2-digit',
-  minute: '2-digit' as '2-digit',
-  second: '2-digit' as '2-digit',
+  hour: '2-digit' as const,
+  minute: '2-digit' as const,
+  second: '2-digit' as const,
   fractionalSecondDigits: 3 // Include milliseconds with 3 digits
 };
 
@@ -50,7 +50,7 @@ export class SolaceClient extends VisualizeClient {
     this.options = options;
 
     //Initializing the solace client library
-    let factoryProps = new solace.SolclientFactoryProperties();
+    const factoryProps = new solace.SolclientFactoryProperties();
     factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
     solace.SolclientFactory.init(factoryProps);
     this.options.logLevel && solace.SolclientFactory.setLogLevel(logLevelMap.get(this.options.logLevel.toUpperCase()) as LogLevel);
@@ -174,9 +174,9 @@ export class SolaceClient extends VisualizeClient {
       else
         return obj[path];
   
-    let field = path.substring(0, path.indexOf('.'));
-    let fieldName = field.replaceAll('[0]', '');
-    var remaining = path.substring(path.indexOf('.')+1);
+    const field = path.substring(0, path.indexOf('.'));
+    const fieldName = field.replaceAll('[0]', '');
+    const remaining = path.substring(path.indexOf('.')+1);
     return this.getSourceFieldValue(field.includes('[0]') ? obj[fieldName][0] : obj[field], remaining);
   }
   
@@ -194,7 +194,7 @@ export class SolaceClient extends VisualizeClient {
           Logger.await(`${chalkEventCounterValue(iter+1)} publishing ${this.options.deliveryMode} message with correlation key ${this.pubConfirmationId} [${new Date().toLocaleString('en-US', dateFormatOptions)}]`) :
           Logger.await(`${chalkEventCounterValue(iter+1)} publishing ${this.options.deliveryMode} message [${new Date().toLocaleString('en-US', dateFormatOptions)}]`);
       }
-      let message = solace.SolclientFactory.createMessage();
+      const message = solace.SolclientFactory.createMessage();
       message.setDestination(solace.SolclientFactory.createTopicDestination(topicName));
       this.options.httpContentEncoding !== undefined && message.setHttpContentEncoding(this.options.httpContentEncoding);
       this.options.httpContentType !== undefined && message.setHttpContentType(this.options.httpContentType);
@@ -261,8 +261,8 @@ export class SolaceClient extends VisualizeClient {
       this.options.appMessageType !== undefined && message.setApplicationMessageType(this.options.appMessageType);
       this.options.replyToTopic !== undefined && message.setReplyTo(solace.SolclientFactory.createTopicDestination(this.options.replyToTopic))
       if (this.options.userProperties) {
-        let propertyMap = new solace.SDTMapContainer();
-        let props:Record<string, string | string[]> = this.options.userProperties;
+        const propertyMap = new solace.SDTMapContainer();
+        const props:Record<string, string | string[]> = this.options.userProperties;
         Object.entries(props).forEach((entry) => {
           propertyMap.addField(entry[0], solace.SDTField.create(solace.SDTFieldType.STRING, entry[1]));
         });
@@ -273,7 +273,7 @@ export class SolaceClient extends VisualizeClient {
         let propertyMap = message.getUserPropertyMap();
         if (!propertyMap) propertyMap = new solace.SDTMapContainer();
         
-        var pKey2 = 'pkey-' + Date.now() % this.options.partitionKeysCount;
+        const pKey2 = 'pkey-' + Date.now() % this.options.partitionKeysCount;
         propertyMap.addField("JMSXGroupID", solace.SDTField.create(solace.SDTFieldType.STRING, pKey2));
         message.setUserPropertyMap(propertyMap);    
       } else if (this.options.partitionKeysList && this.options.partitionKeysList.length) {
@@ -288,15 +288,15 @@ export class SolaceClient extends VisualizeClient {
           this.options.partitionKeys = '';
         }
         
-        var fields = this.options.partitionKeys.split('|').map((field:string) => field.trim());
+        const fields = this.options.partitionKeys.split('|').map((field:string) => field.trim());
         if (fields.length) {
           let propertyMap = message.getUserPropertyMap();
           if (!propertyMap) propertyMap = new solace.SDTMapContainer();
           
-          var values:string[] = [];
+          const values:string[] = [];
           fields.forEach((field:string) => {
             try {
-              let val:string = this.getSourceFieldValue(payload, field);
+              const val:string = this.getSourceFieldValue(payload, field);
               values.push(val);
             } catch (error:any) {
               Logger.logWarn(`failed to get field value for ${field} - ${error.toString()}`)
@@ -332,7 +332,7 @@ export class SolaceClient extends VisualizeClient {
       this.options.publishConfirmation ?
         Logger.await(`${chalkEventCounterValue(iter+1)} publishing ${this.options.deliveryMode} message with correlation key ${this.pubConfirmationId} [${new Date().toLocaleString('en-US', dateFormatOptions)}]`) :
         Logger.await(`${chalkEventCounterValue(iter+1)} publishing ${this.options.deliveryMode} message [${new Date().toLocaleString('en-US', dateFormatOptions)}]`);
-      let message = solace.SolclientFactory.createMessage();
+      const message = solace.SolclientFactory.createMessage();
       message.setDestination(solace.SolclientFactory.createDurableQueueDestination(queueName));
       this.options.httpContentEncoding !== undefined && message.setHttpContentEncoding(this.options.httpContentEncoding);
       this.options.httpContentType !== undefined && message.setHttpContentType(this.options.httpContentType);
@@ -388,8 +388,8 @@ export class SolaceClient extends VisualizeClient {
       this.options.appMessageType !== undefined && message.setApplicationMessageType(this.options.appMessageType);
       this.options.replyToTopic !== undefined && message.setReplyTo(solace.SolclientFactory.createTopicDestination(this.options.replyToTopic))
       if (this.options.userProperties) {
-        let propertyMap = new solace.SDTMapContainer();
-        let props:Record<string, string | string[]> = this.options.userProperties;
+        const propertyMap = new solace.SDTMapContainer();
+        const props:Record<string, string | string[]> = this.options.userProperties;
         Object.entries(props).forEach((entry) => {
           propertyMap.addField(entry[0], solace.SDTField.create(solace.SDTFieldType.STRING, entry[1]));
         });
@@ -400,7 +400,7 @@ export class SolaceClient extends VisualizeClient {
         let propertyMap = message.getUserPropertyMap();
         if (!propertyMap) propertyMap = new solace.SDTMapContainer();
 
-        var pKey2 = 'pkey-' + Date.now() % this.options.partitionKeysCount;
+        const pKey2 = 'pkey-' + Date.now() % this.options.partitionKeysCount;
         propertyMap.addField("JMSXGroupID", solace.SDTField.create(solace.SDTFieldType.STRING, pKey2));
         message.setUserPropertyMap(propertyMap);
       } else if (this.options.partitionKeysList && this.options.partitionKeysList.length) {
@@ -415,15 +415,15 @@ export class SolaceClient extends VisualizeClient {
           this.options.partitionKeys = '';
         }
 
-        var fields = this.options.partitionKeys.split('|').map((field:string) => field.trim());
+        const fields = this.options.partitionKeys.split('|').map((field:string) => field.trim());
         if (fields.length) {
           let propertyMap = message.getUserPropertyMap();
           if (!propertyMap) propertyMap = new solace.SDTMapContainer();
 
-          var values:string[] = [];
+          const values:string[] = [];
           fields.forEach((field:string) => {
             try {
-              let val:string = this.getSourceFieldValue(payload, field);
+              const val:string = this.getSourceFieldValue(payload, field);
               values.push(val);
             } catch (error:any) {
               Logger.logWarn(`failed to get field value for ${field} - ${error.toString()}`);

--- a/src/common/queue-client.ts
+++ b/src/common/queue-client.ts
@@ -74,8 +74,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get queues successful`)
-          let result = data.data;
-          var queues = "";
+          const result = data.data;
+          let queues = "";
           queues += `\n${prettyJSON(JSON.stringify(result))}`
           Logger.logDetailedSuccess(`Details of queue ${this.options.queue} on vpn ${this.options.sempVpn}`, queues)
           await this.listSubscription(this.options.queue)
@@ -107,8 +107,8 @@ export class SempClient {
           process.exit(1)
         } else {
           Logger.logSuccess(`get queues list successful`)
-          let result = data.data;
-          var queues = "";
+          const result = data.data;
+          let queues = "";
           result.forEach((q:any) => queues += `\n${q.queueName}`)
           Logger.logDetailedSuccess(`${result.length} queue(s) found on vpn ${this.options.sempVpn}`, queues)
         }
@@ -214,7 +214,7 @@ export class SempClient {
   }
 
   async listSubscription(queueName: string) {
-    var sempUrl = this.options.sempUrl + `${this.urlFixture}/msgVpns/${this.options.sempVpn}/queues/${encodeURIComponent(queueName)}/subscriptions`;
+    const sempUrl = this.options.sempUrl + `${this.urlFixture}/msgVpns/${this.options.sempVpn}/queues/${encodeURIComponent(queueName)}/subscriptions`;
     await fetch(sempUrl, {
       method: "GET",
       credentials: 'same-origin',
@@ -231,8 +231,8 @@ export class SempClient {
       if (data.meta.error) {
         Logger.logDetailedWarn(`list subscription on queue '${this.options?.queue}' encountered error`, `${decodeURIComponent(data.meta.error.description)}`)
       } else {
-        let result = data.data;
-        var subs = "";
+        const result = data.data;
+        let subs = "";
         result.forEach((sub:any) => subs += `\n${sub.subscriptionTopic}`)
         result.length && Logger.logDetailedSuccess(`${result.length} subscription(s) found on queue ${this.options.queue}`, subs)
       }
@@ -328,8 +328,8 @@ export class SempClient {
         if (data.meta.error) {
           Logger.logDetailedWarn(`list subscription on queue '${this.options?.queue}' encountered error`, `${decodeURIComponent(data.meta.error.description)}`)
         } else {
-          let result = data.data;
-          var subs = "";
+          const result = data.data;
+          let subs = "";
           result.forEach((sub:any) => subs += `\n${sub.subscriptionTopic}`)
           Logger.logDetailedSuccess(`${result.length} subscription(s) found on queue ${this.options.queue}`, subs)
         }

--- a/src/common/receive-client.ts
+++ b/src/common/receive-client.ts
@@ -18,12 +18,12 @@ const logLevelMap:Map<string, LogLevel> = new Map<string, LogLevel>([
 
 const dateFormatOptions: Intl.DateTimeFormatOptions = {
   hour12: false,
-  year: 'numeric' as 'numeric',
-  month: '2-digit' as '2-digit',
-  day: '2-digit' as '2-digit',
-  hour: '2-digit' as '2-digit',
-  minute: '2-digit' as '2-digit',
-  second: '2-digit' as '2-digit',
+  year: 'numeric' as const,
+  month: '2-digit' as const,
+  day: '2-digit' as const,
+  hour: '2-digit' as const,
+  minute: '2-digit' as const,
+  second: '2-digit' as const,
   fractionalSecondDigits: 3 // Include milliseconds with 3 digits
 };
 
@@ -43,7 +43,7 @@ export class SolaceClient extends VisualizeClient {
     this.options = options;
 
     //Initializing the solace client library
-    let factoryProps = new solace.SolclientFactoryProperties();
+    const factoryProps = new solace.SolclientFactoryProperties();
     factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
     solace.SolclientFactory.init(factoryProps);
     this.options.logLevel && solace.SolclientFactory.setLogLevel(logLevelMap.get(this.options.logLevel.toUpperCase()) as LogLevel);
@@ -141,13 +141,13 @@ export class SolaceClient extends VisualizeClient {
         //SUBSCRIPTION_OK implies that a subscription was successfully applied/removed from the broker
         this.session.on(solace.SessionEventCode.SUBSCRIPTION_OK, (sessionEvent: solace.SessionEvent) => {
           //Check if the topic exists in the map
-          let key:string = sessionEvent.correlationKey ? sessionEvent.correlationKey.toString() : '';
+          const key:string = sessionEvent.correlationKey ? sessionEvent.correlationKey.toString() : '';
           if (!key) {
             Logger.logError(`session subscription activity missing correlation-key`);
             return;
           }
 
-          let subscription = !this.receiver.topics.has(key);
+          const subscription = !this.receiver.topics.has(key);
           if (subscription) {
             // subscription exists, remove the topic from the map
             this.receiver.topics.delete(key);
@@ -164,10 +164,10 @@ export class SolaceClient extends VisualizeClient {
           Logger.await(`${chalkEventCounterLabel(++this.count)} receiving message [${new Date().toLocaleString('en-US', dateFormatOptions)}]`)
           Logger.logSuccess(`received ${getType(message)} message on topic ${message.getDestination()}`)
           //Get the topic name from the message's destination
-          let topicName: string = message.getDestination().getName();
+          const topicName: string = message.getDestination().getName();
           if (!this.receiver.topics.has(topicName)) {
             let matched:boolean = false;
-            for (let topic of Array.from(this.receiver.topics.keys())) {
+            for (const topic of Array.from(this.receiver.topics.keys())) {
               let sub = topic as string
               if (sub.startsWith('#share'))
                 sub = sub.split('/').slice(2).join('/');;
@@ -285,7 +285,7 @@ export class SolaceClient extends VisualizeClient {
       return;
     }
 
-    let topicList:string[] = [];
+    const topicList:string[] = [];
     if (typeof topicNames === 'string')
       topicList.push(topicNames);
     else if (typeof topicNames === 'object')

--- a/src/common/reply-client.ts
+++ b/src/common/reply-client.ts
@@ -39,7 +39,7 @@ export class SolaceClient extends VisualizeClient {
     this.replier.subscribed = [];
 
     //Initializing the solace client library
-    let factoryProps = new solace.SolclientFactoryProperties();
+    const factoryProps = new solace.SolclientFactoryProperties();
     factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
     solace.SolclientFactory.init(factoryProps);
     this.options.logLevel && solace.SolclientFactory.setLogLevel(logLevelMap.get(this.options.logLevel.toUpperCase()) as LogLevel);
@@ -114,7 +114,7 @@ export class SolaceClient extends VisualizeClient {
         // define message event listener
         this.session.on(solace.SessionEventCode.MESSAGE, (message: any) => {
           try {
-            var request:any = message as string;
+            const request:any = message as string;
             this.publishVisualizationEvent(this.session, this.options, STM_EVENT_REQUEST_RECEIVED, { 
               type: 'replier', topicName: request.getDestination().getName(), clientName: this.clientName, uuid: uuid(), msgId: message.getApplicationMessageId() 
             })    
@@ -197,7 +197,7 @@ export class SolaceClient extends VisualizeClient {
     Logger.logSuccess(`request received - ${message.getDestination()}, type - ${getType(message)}`)
     Logger.dumpMessage(message, this.options.outputMode, this.options.pretty);
     if (this.session !== null) {
-      var reply = solace.SolclientFactory.createMessage();
+      const reply = solace.SolclientFactory.createMessage();
       this.options.httpContentEncoding && reply.setHttpContentEncoding(this.options.httpContentEncoding);
       this.options.httpContentType && reply.setHttpContentType(this.options.httpContentType);
       if (payload) {
@@ -206,7 +206,7 @@ export class SolaceClient extends VisualizeClient {
             if (typeof payload === 'object') {
               reply.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, JSON.stringify(payload)));
             } else {
-              var jsonPayload = JSON.parse(payload.toString());
+              const jsonPayload = JSON.parse(payload.toString());
               reply.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, JSON.stringify(jsonPayload)));
             }
           } catch (error) {

--- a/src/common/request-client.ts
+++ b/src/common/request-client.ts
@@ -38,7 +38,7 @@ export class SolaceClient extends VisualizeClient {
     this.requestor.topicName = this.options.topic ? this.options.topic : getDefaultTopic('request');
 
     //Initializing the solace client library
-    let factoryProps = new solace.SolclientFactoryProperties();
+    const factoryProps = new solace.SolclientFactoryProperties();
     factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
     solace.SolclientFactory.init(factoryProps);
     this.options.logLevel && solace.SolclientFactory.setLogLevel(logLevelMap.get(this.options.logLevel.toUpperCase()) as LogLevel);
@@ -122,7 +122,7 @@ export class SolaceClient extends VisualizeClient {
     }
     
     Logger.await(`${chalkEventCounterLabel(iter)} requesting...`);
-    var request = solace.SolclientFactory.createMessage();
+    const request = solace.SolclientFactory.createMessage();
     request.setDestination(solace.SolclientFactory.createTopicDestination(topicName));
     this.options.httpContentEncoding && request.setHttpContentEncoding(this.options.httpContentEncoding);
     this.options.httpContentType && request.setHttpContentType(this.options.httpContentType);
@@ -133,7 +133,7 @@ export class SolaceClient extends VisualizeClient {
           if (typeof payload === 'object') {
             request.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, JSON.stringify(payload)));
           } else {
-            var jsonPayload = JSON.parse(payload.toString());
+            const jsonPayload = JSON.parse(payload.toString());
             request.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, JSON.stringify(jsonPayload)));
           }
         } catch (error) {
@@ -165,8 +165,8 @@ export class SolaceClient extends VisualizeClient {
     this.options.appMessageType && request.setApplicationMessageType(this.options.appMessageType);
     this.options.replyToTopic && request.setReplyTo(solace.SolclientFactory.createTopicDestination(this.options.replyToTopic))
     if (this.options.userProperties) {
-      let propertyMap = new solace.SDTMapContainer();
-      let props:Record<string, string | string[]> = this.options.userProperties;
+      const propertyMap = new solace.SDTMapContainer();
+      const props:Record<string, string | string[]> = this.options.userProperties;
       Object.entries(props).forEach((entry) => {
         propertyMap.addField(entry[0], solace.SDTField.create(solace.SDTFieldType.STRING, entry[1]));
       });

--- a/src/common/visualize-client.ts
+++ b/src/common/visualize-client.ts
@@ -13,7 +13,7 @@ export class VisualizeClient {
       return;
     }
     try {
-      let message = solace.SolclientFactory.createMessage();
+      const message = solace.SolclientFactory.createMessage();
       message.setDestination(solace.SolclientFactory.createTopicDestination(topicName));
       message.setBinaryAttachment(JSON.stringify(payload));
       message.setDeliveryMode(MessageDeliveryModeType.DIRECT);

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,13 +71,13 @@ export class Commander {
     if (!this.online) 
       return '';
 
-    var now = Date.now();
+    const now = Date.now();
     const oneDay = 24 * 60 * 60 * 1000; // 1 day
     // const oneDay = 10 * 1000; // 10 secs
 
     if (!this.newVersionFound && this.lastChecked && (now - this.lastChecked) > oneDay) {
       const fetch = require('sync-fetch')
-      var latestVersion = undefined;
+      let latestVersion = undefined;
 
       try {
         latestVersion = fetch('https://api.github.com/repos/SolaceLabs/solace-tryme-cli/releases/latest', {
@@ -350,7 +350,7 @@ if (process.env.SHOW_VISUALIZATION) {
       this.newVersionCheck();
       const optionsSource:any = {};
       const defaultKeys = Object.keys(defaultMessageConnectionConfig);
-      for (var i=0; i<defaultKeys.length; i++) {
+      for (let i=0; i<defaultKeys.length; i++) {
         optionsSource[defaultKeys[i]] = configListCmd.getOptionValueSource(defaultKeys[i]);
       }
 
@@ -368,7 +368,7 @@ if (process.env.SHOW_VISUALIZATION) {
       this.newVersionCheck();
       const optionsSource:any = {};
       const defaultKeys = Object.keys(defaultMessageConnectionConfig);
-      for (var i=0; i<defaultKeys.length; i++) {
+      for (let i=0; i<defaultKeys.length; i++) {
         optionsSource[defaultKeys[i]] = configDeleteCmd.getOptionValueSource(defaultKeys[i]);
       }
 
@@ -568,7 +568,7 @@ if (process.env.SHOW_VISUALIZATION) {
     feedValidateCmd.action((options: ManageFeedClientOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = feedValidateCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 
@@ -586,7 +586,7 @@ if (process.env.SHOW_VISUALIZATION) {
     feedPreviewCmd.action((options: ManageFeedClientOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = feedPreviewCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 
@@ -602,7 +602,7 @@ if (process.env.SHOW_VISUALIZATION) {
     generateCmd.action((options: ManageFeedClientOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = generateCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
       // Capture AI enhancement option source
@@ -621,7 +621,7 @@ if (process.env.SHOW_VISUALIZATION) {
     configureCmd.action((options: ManageFeedClientOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = configureCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 
@@ -673,7 +673,7 @@ if (process.env.SHOW_VISUALIZATION) {
     feedListCmd.action((options: ManageFeedPublishOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = feedListCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 
@@ -689,7 +689,7 @@ if (process.env.SHOW_VISUALIZATION) {
     feedImportCmd.action((options: ManageFeedPublishOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = feedImportCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 
@@ -705,7 +705,7 @@ if (process.env.SHOW_VISUALIZATION) {
     feedExportCmd.action((options: ManageFeedPublishOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = feedExportCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 
@@ -721,7 +721,7 @@ if (process.env.SHOW_VISUALIZATION) {
     feedDownloadCmd.action((options: ManageFeedPublishOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = feedDownloadCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 
@@ -737,7 +737,7 @@ if (process.env.SHOW_VISUALIZATION) {
     feedContributeCmd.action((options: ManageFeedPublishOptions) => {
       const optionsSource:any = {};
       const defaultFeedKeys = Object.keys(defaultFeedConfig);
-      for (var i=0; i<defaultFeedKeys.length; i++) {
+      for (let i=0; i<defaultFeedKeys.length; i++) {
         optionsSource[defaultFeedKeys[i]] = feedContributeCmd.getOptionValueSource(defaultFeedKeys[i]);
       }
 

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -10,7 +10,7 @@ const connection = (options: ManageClientOptions, optionsSource: any) => {
     process.exit(0);
   }
 
-  var count = 0;
+  let count = 0;
   Object.keys(optionsSource).forEach(key => count += optionsSource[key] === 'cli' ? 1 : 0)
   if (!count) {
     Logger.error('specify at least one or more parameters')

--- a/src/lib/feed-analyze.ts
+++ b/src/lib/feed-analyze.ts
@@ -7,7 +7,7 @@ import { validateAsyncAPI } from './feed-validate';
 import { chalkBoldError, chalkBoldWarning } from '../utils/chalkUtils';
 
 const validateSchema = (schema: any) => {
-  var jsonParser = new JsonSchemaParser(schema);
+  const jsonParser = new JsonSchemaParser(schema);
   if (!jsonParser.validate()) {
     Logger.error('Invalid schema');
     process.exit(1);
@@ -17,9 +17,9 @@ const validateSchema = (schema: any) => {
 }
 
 const getChannelMessages = (channel:any) => {
-  let messages:any = {};
+  const messages:any = {};
   Array.from(channel.messages()).map((arr:any) => {
-    let key = arr.id() ? arr.id() : arr.name();
+    const key = arr.id() ? arr.id() : arr.name();
     messages[key] = arr.json()
     if (arr.hasPayload())
       validateSchema(arr.payload().json())
@@ -28,34 +28,34 @@ const getChannelMessages = (channel:any) => {
 }
 
 const getOpMessages = (op:any) => {
-  let messages:any = {};
+  const messages:any = {};
   Array.from(op.messages()).map((arr:any) => {
-    let key = arr.id() ? arr.id() : arr.name();
+    const key = arr.id() ? arr.id() : arr.name();
     messages[key] = arr.json()
   })
   return messages;
 }
 
 const getChannelParameters = (channel:any) => {
-  let parameters:any = {};
+  const parameters:any = {};
   Array.from(channel.parameters()).map((arr:any) => {
-    let key = arr.id() ? arr.id() : arr.name();
+    const key = arr.id() ? arr.id() : arr.name();
     parameters[key] = arr.json()
   })
   return parameters;
 }
 
 const getChannelServers = (channel:any) => {
-  let servers:any = {};
+  const servers:any = {};
   Array.from(channel.servers()).map((arr:any) => {
-    let key = arr.id() ? arr.id() : arr.name();
+    const key = arr.id() ? arr.id() : arr.name();
     servers[key] = arr.json()
   })
   return servers;
 }
 
 const getChannelBindings = (channel:any) => {
-  let bindings:any = {};
+  const bindings:any = {};
   Array.from(channel.bindings()).map((arr:any) => {
     bindings[arr.protocol()] = arr.json()
   })
@@ -179,7 +179,7 @@ const enhanceRuleWithValidatorsAndFormats = (schema: any, rule: any) => {
 
 const setDefaultTopicVariableRules = (obj: any) => {
   for(const prop in obj) {
-    var schema = obj[prop].schema;
+    let schema = obj[prop].schema;
     schema = !schema || !schema.type ? { ...obj[prop], type: 'string' } : schema;
     if (schema.type.toLowerCase() === 'string') {
       obj[prop].rule = schema.enum ? 
@@ -232,7 +232,7 @@ const processObjectPayload = async (payload: any) => {
       if (payload[prop].properties) 
         processObjectPayload(payload[prop].properties);
       else {
-        let keys = Object.keys(payload[prop]);
+        const keys = Object.keys(payload[prop]);
         if (keys.includes('allOf') && payload[prop]['allOf'].length) {
           payload[prop].properties = payload[prop]['allOf'][0].properties;
           processObjectPayload(payload[prop].properties);
@@ -306,7 +306,7 @@ const processObjectPayload = async (payload: any) => {
     }
 
     var schema = payload[prop];
-    var schemaType = schema.type;
+    const schemaType = schema.type;
     if (!schemaType) {
       console.warn(chalkBoldWarning(`Missing type for property ${prop}, setting default type to 'string'`));
     }
@@ -373,12 +373,12 @@ const processPayloadField = (payload: any) => {
 }
 
 const processArrayPayload = (payload: any) => {
-  var prop = 'items';
+  const prop = 'items';
   payload[prop].rule = { name: prop, type: 'array', subType: 'object'};
   if (payload[prop].properties) 
     processPayload(payload[prop].properties)
   else {
-    let keys = Object.keys(payload[prop]);
+    const keys = Object.keys(payload[prop]);
     if (keys.includes('allOf') && payload[prop]['allOf'].length) {
       payload[prop].properties = payload[prop]['allOf'][0].properties;
       payload[prop].type = payload[prop]['allOf'][0].type;
@@ -416,7 +416,7 @@ const processArrayPayload = (payload: any) => {
 const processPayload = (msg: any) => {
   // Logger.info('processing message: ' + JSON.stringify(msg));
   // Logger.info('message type: ' + msg.type);
-  var payload = msg.payload;
+  let payload = msg.payload;
   // Logger.info('payload type: ' + payload.type);
 
   if (!payload && msg.properties) {
@@ -434,7 +434,7 @@ const processPayload = (msg: any) => {
 
 const setDefaultPayloadRules = (msgs: any) => {
   msgs.forEach(async (msg:any) => {
-    var payload = msg.payload;
+    let payload = msg.payload;
     if (payload && payload.type === 'object' && payload.properties) {
       msg.payload = { ...payload.properties }
       payload = msg.payload;
@@ -466,7 +466,7 @@ const setDefaultPayloadRules = (msgs: any) => {
 
 const checkIfPlainJson = (schemaFormant: string) => {
   const jsonFormats = ['vnd.aai.asyncapi+json;', 'application/json;'];
-  let plainJson = jsonFormats.some((format: string) =>
+  const plainJson = jsonFormats.some((format: string) =>
     schemaFormant.toLowerCase().includes(format.toLowerCase())
   );
   return plainJson;
@@ -474,7 +474,7 @@ const checkIfPlainJson = (schemaFormant: string) => {
 
 const checkSchemaFormat = (schemaFormat: string) => {
   const supportedSchemaFormats = ['vnd.aai.asyncapi+json', 'application/schema+yaml', 'vnd.aai.asyncapi', 'json', 'avro'];
-  let supported = supportedSchemaFormats.some((format: string) => 
+  const supported = supportedSchemaFormats.some((format: string) => 
     schemaFormat.toLowerCase().includes(format.toLowerCase())
   );
   return supported;
@@ -572,7 +572,7 @@ const fixUpPayloadApplicators = (payload:any):any => {
     if (payload.properties) {
       return fixUpPayloadApplicators(payload.properties);
     } else {
-      let keys = Object.keys(payload);
+      const keys = Object.keys(payload);
       if (keys.includes('allOf')) {
         return fixUpPayloadApplicators(payload['allOf'][0]);
       } else if (keys.includes('anyOf')) {
@@ -584,7 +584,7 @@ const fixUpPayloadApplicators = (payload:any):any => {
       }
     }
   } else {
-    let keys = Object.keys(payload);
+    const keys = Object.keys(payload);
     if (keys.includes('allOf')) {
       return fixUpPayloadApplicators(payload['allOf'][0]);
     } else if (keys.includes('anyOf')) {
@@ -674,7 +674,7 @@ const load = async (asyncApiSchema: Input, validate: boolean = true) => {
 }
 
 const validateTopic = (topic: string) => {
-  let tokens = topic.split('/');
+  const tokens = topic.split('/');
   let valid = true;
   valid = tokens.length > 0;
   if (!valid) return false;
@@ -718,8 +718,8 @@ const analyze = async (document: AsyncAPIDocumentInterface, reverse:boolean = fa
 
   // extract topics
   _channels.forEach((channel:Channel) => {
-    let operations:any = channel.operations();
-    let sendOps:any = reverse ?
+    const operations:any = channel.operations();
+    const sendOps:any = reverse ?
                         Array.from(operations).filter((o:any) => !o.isSend()) :
                         Array.from(operations).filter((o:any) => o.isSend());
     if (sendOps.length) {
@@ -741,7 +741,7 @@ const analyze = async (document: AsyncAPIDocumentInterface, reverse:boolean = fa
       })
     }
 
-    let receiveOps = reverse ?
+    const receiveOps = reverse ?
                         Array.from(operations).filter((o:any) => !o.isReceive()) :
                         Array.from(operations).filter((o:any) => o.isReceive());
     if (receiveOps.length) {
@@ -761,7 +761,7 @@ const analyze = async (document: AsyncAPIDocumentInterface, reverse:boolean = fa
   // extract schemas 
   _schemas.forEach((schema:any) => {
     validateSchema(schema.json())
-    let id = schema.id();
+    const id = schema.id();
     api.schemas[id] = schema.json();
   });
 
@@ -790,7 +790,7 @@ const analyze = async (document: AsyncAPIDocumentInterface, reverse:boolean = fa
 
   // classify message-based send/receive contexts
   Object.keys(sendChannels).forEach((topic:any) => {
-    let channel = sendChannels[topic];
+    const channel = sendChannels[topic];
     Object.keys(channel.messages).forEach((messageName:any) => {
       api.messages[messageName].send.push({
         topicName: channel.address,
@@ -804,7 +804,7 @@ const analyze = async (document: AsyncAPIDocumentInterface, reverse:boolean = fa
   })
   
   Object.keys(receiveChannels).forEach((topic:any) => {
-    let channel = receiveChannels[topic];
+    const channel = receiveChannels[topic];
     Object.keys(channel.messages).forEach((messageName:any) => {
       api.messages[messageName].receive.push({
         topicName: channel.address,
@@ -847,8 +847,8 @@ const analyzeV2 = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
 
   // extract topics
   _channels.forEach((channel:Channel) => {
-    let operations:any = channel.operations();
-    let sendOps:any = reverse ?
+    const operations:any = channel.operations();
+    const sendOps:any = reverse ?
                           Array.from(operations).filter((o:any) => !o.isSend()) :
                           Array.from(operations).filter((o:any) => o.isSend());
     if (sendOps.length) {
@@ -868,7 +868,7 @@ const analyzeV2 = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
       }
     }
 
-    let receiveOps = reverse ?
+    const receiveOps = reverse ?
                         Array.from(operations).filter((o:any) => !o.isReceive()) :
                         Array.from(operations).filter((o:any) => o.isReceive());
     if (receiveOps.length) {
@@ -886,7 +886,7 @@ const analyzeV2 = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
   // extract schemas 
   _schemas.forEach((schema:any) => {
     validateSchema(schema.json())
-    let id = schema.id();
+    const id = schema.id();
     api.schemas[id] = schema.json();
   });
 
@@ -897,7 +897,7 @@ const analyzeV2 = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
   
   // extract messages
   _messages.forEach((message:any) => {
-    let key = message.id() ? message.id() : message.name();
+    const key = message.id() ? message.id() : message.name();
     api.messages[key] = {
       send: [],
       receive: [],
@@ -908,7 +908,7 @@ const analyzeV2 = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
 
   // classify message-based send/receive contexts
   Object.keys(sendChannels).forEach((topic:any) => {
-    let channel = sendChannels[topic];
+    const channel = sendChannels[topic];
     Object.keys(channel.messages).forEach((messageName:any) => {
       api.messages[messageName].send.push({
         topicName: topic,
@@ -922,7 +922,7 @@ const analyzeV2 = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
   })
   
   Object.keys(receiveChannels).forEach((topic:any) => {
-    let channel = receiveChannels[topic];
+    const channel = receiveChannels[topic];
     Object.keys(channel.messages).forEach((messageName:any) => {
       api.messages[messageName].receive.push({
         topicName: topic,
@@ -965,8 +965,8 @@ const analyzeEP = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
 
   // extract topics
   _channels.forEach((channel:Channel) => {
-    let operations:any = channel.operations();
-    let sendOps:any = reverse ? 
+    const operations:any = channel.operations();
+    const sendOps:any = reverse ? 
                         Array.from(operations).filter((o:any) => !o.isSend()) :
                         Array.from(operations).filter((o:any) => o.isSend());
     if (sendOps.length) {
@@ -986,7 +986,7 @@ const analyzeEP = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
       }
     }
 
-    let receiveOps = reverse ?
+    const receiveOps = reverse ?
                         Array.from(operations).filter((o:any) => !o.isReceive()) :
                         Array.from(operations).filter((o:any) => o.isReceive());
     if (receiveOps.length) {
@@ -1004,7 +1004,7 @@ const analyzeEP = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
   // extract schemas 
   _schemas.forEach((schema:any) => {
     validateSchema(schema.json())
-    let id = schema.id();
+    const id = schema.id();
     api.schemas[id] = schema.json();
   });
 
@@ -1025,7 +1025,7 @@ const analyzeEP = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
 
   // classify message-based send/receive contexts
   Object.keys(sendChannels).forEach((topic:any) => {
-    let channel = sendChannels[topic];
+    const channel = sendChannels[topic];
     Object.keys(channel.messages).forEach((messageName:any) => {
       api.messages[messageName].send.push({
         topicName: topic,
@@ -1039,7 +1039,7 @@ const analyzeEP = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
   })
   
   Object.keys(receiveChannels).forEach((topic:any) => {
-    let channel = receiveChannels[topic];
+    const channel = receiveChannels[topic];
     Object.keys(channel.messages).forEach((messageName:any) => {
       api.messages[messageName].receive.push({
         topicName: topic,
@@ -1060,24 +1060,24 @@ const analyzeEP = async (document: AsyncAPIDocumentInterface, reverse:boolean = 
 }
 
 const formulateRules = (document:AsyncAPIDocumentInterface|undefined, reverse:boolean = false) => {
-  var ruleSet:any = [];
+  const ruleSet:any = [];
 
   const checkHasPayload = (message:any) => {
     if (!message?.hasPayload())
       return false;
 
-    let obj = message?.payload()?.json();
-    let keys = Object.keys(obj).filter((k:any) => !k.startsWith('x-'));
+    const obj = message?.payload()?.json();
+    const keys = Object.keys(obj).filter((k:any) => !k.startsWith('x-'));
     return keys.length > 0;
   };
 
-  let _info = document?.info();
+  const _info = document?.info();
 
   document?.operations().forEach((_operation) => {
-    let consideration = reverse ? _operation.isReceive() : _operation.isSend();
+    const consideration = reverse ? _operation.isReceive() : _operation.isSend();
     if (consideration) {
-      let _channels = _operation.channels();
-      let _messages = _operation.messages();
+      const _channels = _operation.channels();
+      const _messages = _operation.messages();
 
       _channels.forEach((channel:any) => {
         Array.from(_messages).map((message:any) => {
@@ -1089,16 +1089,16 @@ const formulateRules = (document:AsyncAPIDocumentInterface|undefined, reverse:bo
             process.exit(1);
           }
             
-          let hasPayload = checkHasPayload(message);
+          const hasPayload = checkHasPayload(message);
           let fixedUpPayload = hasPayload ? 
                                     fixUpMessageApplicators(message?.payload()?.json()) : 
                                     undefined;
-          let plainJson = hasPayload ? checkIfPlainJson(message.schemaFormat()) : false;
+          const plainJson = hasPayload ? checkIfPlainJson(message.schemaFormat()) : false;
           if (plainJson) {
             fixedUpPayload = fixUpJsonPayload(fixedUpPayload, fixedUpPayload);
           }
 
-          let rule = {
+          const rule = {
             topic: channel.address(),
             topicParameters: getChannelParameters(channel),
             eventName: message.extensions().get('x-ep-event-name') ? 
@@ -1132,7 +1132,7 @@ const formulateRules = (document:AsyncAPIDocumentInterface|undefined, reverse:bo
 }
 
 const formulateSchemas = (document:AsyncAPIDocumentInterface|undefined) => {
-  var schemaSet:any = [];
+  const schemaSet:any = [];
 
   document?.schemas().forEach((_schema) => {
     schemaSet[_schema.id()] = _schema.json();

--- a/src/lib/feed-archive.ts
+++ b/src/lib/feed-archive.ts
@@ -6,9 +6,9 @@ import { defaultFakerRulesFile, defaultFeedAnalysisFile, defaultFeedApiEndpointF
 import { getGitEventFeeds, getLocalEventFeeds } from '../utils/listfeeds';
 
 const feedDownload = async (options: ManageFeedClientOptions, optionsSource: any) => {
-  var feedName = '';
-  var gitFeed = false;
-  var info = null;
+  let feedName = '';
+  let gitFeed = false;
+  let info = null;
 
   const { Select, Input, AutoComplete } = require('enquirer');
   if (optionsSource.communityOnly === 'cli') {
@@ -135,17 +135,17 @@ const feedDownload = async (options: ManageFeedClientOptions, optionsSource: any
 
   const zlib = require("zip-lib");
 
-  var exportPath = `${process.cwd()}/export`;
-  var zipPath = `${exportPath}/${feedName}`;
+  const exportPath = `${process.cwd()}/export`;
+  const zipPath = `${exportPath}/${feedName}`;
   if (fileExists(exportPath)) fs.rmdirSync(exportPath, { recursive: true });
   fs.mkdirSync(exportPath, { recursive: true });
 
-  var data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedInfoFile) : loadLocalFeedFile(feedName, defaultFeedInfoFile);
+  let data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedInfoFile) : loadLocalFeedFile(feedName, defaultFeedInfoFile);
   writeJsonFile(`${zipPath}/${defaultFeedInfoFile}`, data);
   if (info.type === 'asyncapi_feed') {
     data = gitFeed ? await loadGitFeedFile(feedName, defaultFeedAnalysisFile) : loadLocalFeedFile(feedName, defaultFeedAnalysisFile);
     writeJsonFile(`${zipPath}/${defaultFeedAnalysisFile}`, data);
-    var asyncApiFile = data.fileName;
+    const asyncApiFile = data.fileName;
     data = gitFeed ? await loadGitFeedFile(feedName, asyncApiFile) : loadLocalFeedFile(feedName, asyncApiFile);
     writeJsonFile(`${zipPath}/${asyncApiFile}`, data);
     data = gitFeed ? await loadGitFeedFile(feedName, defaultFakerRulesFile) : loadLocalFeedFile(feedName, defaultFakerRulesFile);

--- a/src/lib/feed-configure.ts
+++ b/src/lib/feed-configure.ts
@@ -15,9 +15,9 @@ import { generateEvent } from '@solace-labs/solace-data-generator';
 
 const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
   const managePort = options.managePort ? options.managePort : 0;
-  var feedName: string | undefined = options.feedName;
-  var publicDir = __dirname.substring(0, __dirname.lastIndexOf(defaultProjectName) + defaultProjectName.length);
-  var feedInfo: any = undefined;
+  let feedName: string | undefined = options.feedName;
+  const publicDir = __dirname.substring(0, __dirname.lastIndexOf(defaultProjectName) + defaultProjectName.length);
+  let feedInfo: any = undefined;
   
   if (options.lint) {
     Logger.logSuccess('linting successful...')
@@ -29,7 +29,7 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
     feedInfo = loadLocalFeedFile(feedName, defaultFeedInfoFile);
   } 
   else {
-    var feeds = getLocalEventFeeds();
+    const feeds = getLocalEventFeeds();
     if (!feeds || !feeds.length) {
       Logger.logError('no local feeds found...')
       process.exit(1);
@@ -131,10 +131,10 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
   
   app.get('/feeds', (req:any, res:any) => {
     if (req.query.feed) {
-      var feed = getFeed(req.query.feed);
+      const feed = getFeed(req.query.feed);
       res.json(feed);
     } else {
-      var feeds = getAllFeeds();
+      const feeds = getAllFeeds();
       res.json(feeds);    
     }
 
@@ -145,13 +145,13 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
       res.status(201).json({error: 'missing feed name'})
     }
 
-    var rules = loadLocalFeedFile(req.query.feed, defaultFakerRulesFile);
+    const rules = loadLocalFeedFile(req.query.feed, defaultFakerRulesFile);
     res.json(rules);    
   })
 
   app.post('/feedrules', async (req:any, res:any) => {
-    var feed = req.body;
-    var result = await updateRules(feed.name, feed.rules);
+    const feed = req.body;
+    const result = await updateRules(feed.name, feed.rules);
     if (result) 
       res.status(200).json({success: 'updated feed rules successfully'});
     else
@@ -159,8 +159,8 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
   })
 
   app.post('/feedsession', async (req:any, res:any) => {
-    var feed = req.body;
-    var result = await updateSession(feed.name, feed.session);
+    const feed = req.body;
+    const result = await updateSession(feed.name, feed.session);
     if (result) 
       res.status(200).json({success: 'updated feed session successfully'});
     else
@@ -181,9 +181,9 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
   })
 
   app.post('/fakedata', (req:any, res:any) => {
-    var data = req.body;
+    const data = req.body;
     try {
-      var fakedData = fakeDataValueGenerator(data);
+      const fakedData = fakeDataValueGenerator(data);
       res.status(200).json(fakedData)
     } catch (error: any) {
       res.status(201).json({error: error.toString() });
@@ -191,9 +191,9 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
   })
 
   app.post('/fakepayload', (req:any, res:any) => {
-    var data = req.body;
+    const data = req.body;
     try {
-      var fakedData = fakeDataObjectGenerator(data);
+      const fakedData = fakeDataObjectGenerator(data);
       res.status(200).json(fakedData)
     } catch (error: any) {
       res.status(201).json({error: error.toString() });
@@ -201,9 +201,9 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
   })
 
   app.post('/fakedata', (req:any, res:any) => {
-    var data = req.body;
+    const data = req.body;
     try {
-      var fakedData = fakeDataValueGenerator(data);
+      const fakedData = fakeDataValueGenerator(data);
       res.status(200).json(fakedData)
     } catch (error: any) {
       res.status(201).json({error: error.toString() });
@@ -211,11 +211,11 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
   })
 
   app.post('/fakeevent', async (req:any, res:any) => {
-    var data = req.body;
-    var result = [];
+    const data = req.body;
+    const result = [];
     try {
-      for (var i=0; i<data.count; i++) {
-        var {topic, payload} = generateEvent(data.rule);
+      for (let i=0; i<data.count; i++) {
+        const {topic, payload} = generateEvent(data.rule);
         result.push({ topic, payload });
       }
       res.status(200).json(result)
@@ -239,11 +239,11 @@ const manage = async (options: ManageFeedClientOptions, optionsSource: any) => {
     setTimeout(process.exit(0), 2000)
   })
 
-  let http = require('http');
-  let server = http.createServer(app);
+  const http = require('http');
+  const server = http.createServer(app);
   server.listen(managePort, () => {
     Logger.info(`App listening on port ${server.address().port}`);
-    var opener = require("opener");
+    const opener = require("opener");
     if (feedName) {
       Logger.info(`Accessible at http://localhost:${server.address().port}/feeds.html?feed=${feedName}`);
       opener(`http://localhost:${server.address().port}/feeds.html?feed=${feedName}`)

--- a/src/lib/feed-contribute.ts
+++ b/src/lib/feed-contribute.ts
@@ -14,11 +14,11 @@ import yaml from 'js-yaml';
 
 const contribute = async (options: ManageFeedClientOptions, optionsSource: any) => {
   const { Confirm, Input, List, AutoComplete } = require('enquirer');
-  var { feedName } = options;
-  var userEmail, contributionChanges = ''
+  let { feedName } = options;
+  let userEmail, contributionChanges = ''
 
   if (!feedName) {
-    var feeds = getLocalEventFeeds();
+    const feeds = getLocalEventFeeds();
     if (!feeds || !feeds.length) {
       Logger.logError('no local feeds found...')
       process.exit(1);
@@ -56,7 +56,7 @@ const contribute = async (options: ManageFeedClientOptions, optionsSource: any) 
 
   Logger.info('Let us first update the feed information\n')
 
-  var info:any = loadLoadFeedInfo(feedName);
+  const info:any = loadLoadFeedInfo(feedName);
   Logger.logMessage(`${chalkBoldWhite('Current Feed Information:')}\n` + prettyJSON(JSON.stringify(info)));
 
   if (info.contributed) {
@@ -77,7 +77,7 @@ const contribute = async (options: ManageFeedClientOptions, optionsSource: any) 
       });
   }
 
-  var infoUpdated = false;
+  let infoUpdated = false;
 
   // Take user input
 
@@ -261,7 +261,7 @@ const contribute = async (options: ManageFeedClientOptions, optionsSource: any) 
 }
 
 async function createPR (feedName:string, info:any, azureFunctionInfo:any, feedLocalPath:string, ) {
-  let PRLink = null
+  const PRLink = null
   // const azureFunctionURL = 'http://127.0.0.1:7071/api/triggerContribute'
   const azureFunctionURL = 'https://stm-contribute.azurewebsites.net/api/triggerContribute'
   // Query EVENT-FEEDS.json
@@ -288,7 +288,7 @@ async function createPR (feedName:string, info:any, azureFunctionInfo:any, feedL
     if (info.type === 'asyncapi_feed') {
       const analysis:any = readFile(`${feedLocalPath}/${defaultFeedAnalysisFile}`);
       //  Create a new FormData object
-      let formData = new FormData();
+      const formData = new FormData();
 
       formData.append('files', JSON.stringify(await readFile(`${feedLocalPath}/${defaultFeedAnalysisFile}`)), defaultFeedAnalysisFile);
       formData.append('files', JSON.stringify(await readFile(`${feedLocalPath}/${defaultFeedSchemasFile}`)), defaultFeedSchemasFile);
@@ -310,7 +310,7 @@ async function createPR (feedName:string, info:any, azureFunctionInfo:any, feedL
     } else if (info.type === 'restapi_feed') {
 
       //  Create a new FormData object
-      let formData = new FormData();
+      const formData = new FormData();
       formData.append('files', JSON.stringify(await readFile(`${feedLocalPath}/${defaultFeedApiEndpointFile}`)), defaultFeedApiEndpointFile);
       formData.append('files', JSON.stringify(await readFile(`${feedLocalPath}/${defaultFeedRulesFile}`)), defaultFeedRulesFile);
       formData.append('files', JSON.stringify(await readFile(`${feedLocalPath}/${defaultFeedSessionFile}`)), defaultFeedSessionFile);
@@ -347,7 +347,7 @@ async function executeFunction (azureFunctionURL:string, formData:FormData) {
       maxBodyLength: Infinity      
     });
 
-    let body  = response.data
+    const body  = response.data
     if(response.status === 200) {
       return body
     } else {

--- a/src/lib/feed-datahelper.ts
+++ b/src/lib/feed-datahelper.ts
@@ -8,14 +8,14 @@ function getSourceFieldValue (obj:any, path:string):any {
   if (path.indexOf('.') < 0)
     return obj[path];
 
-  let field = path.substring(0, path.indexOf('.'));
-  let fieldName = field.replaceAll('[0]', '');
-  var remaining = path.substring(path.indexOf('.')+1);
+  const field = path.substring(0, path.indexOf('.'));
+  const fieldName = field.replaceAll('[0]', '');
+  const remaining = path.substring(path.indexOf('.')+1);
   return getSourceFieldValue(field.includes('[0]') ? obj[fieldName][0] : obj[field], remaining);
 }
         
 function setTargetFieldValue(obj:any, path:string, value:any) {
-  var tokens = path.split('.');
+  const tokens = path.split('.');
   if (tokens.length <= 1) {
     if (Array.isArray(obj)) {
       obj.forEach(aObj => {
@@ -30,29 +30,29 @@ function setTargetFieldValue(obj:any, path:string, value:any) {
     return;
   }
 
-  let field = path.substring(0, path.indexOf('.'));
-  let fieldName = field.replaceAll('[0]', '');
-  var remaining = path.substring(path.indexOf('.')+1);
+  const field = path.substring(0, path.indexOf('.'));
+  const fieldName = field.replaceAll('[0]', '');
+  const remaining = path.substring(path.indexOf('.')+1);
   setTargetFieldValue(field.includes('[0]') ? obj[fieldName][0] : obj[field], remaining, value);
 }
 
 export function getField (obj:any, path:string):any {
-  var tokens = path.split('.');
+  const tokens = path.split('.');
   if (tokens.length <= 1)
     return obj;
 
-  let field = path.substring(0, path.indexOf('.'));
-  var remaining = path.substring(path.indexOf('.')+1);
+  const field = path.substring(0, path.indexOf('.'));
+  const remaining = path.substring(path.indexOf('.')+1);
   return getField(obj[field], remaining);
 }
 
 const fakeEventGenerator = async (data:any) => {
-  var backwardCompatibility = typeof data?.rule?.hasPayload === 'undefined' ? true : false;
-  var payloads = backwardCompatibility || data?.rule?.hasPayload  ? 
+  const backwardCompatibility = typeof data?.rule?.hasPayload === 'undefined' ? true : false;
+  const payloads = backwardCompatibility || data?.rule?.hasPayload  ? 
                     fakeDataObjectGenerator({ payload: data.rule.payload, count: data.count}) : 
                     Array(data.count).fill({});
-  var fakeData = [];
-  var mappedTopicParams:any = [];
+  const fakeData = [];
+  const mappedTopicParams:any = [];
   if (data.rule.mappings && data.rule.mappings.length) {
     for (var j=0; j<data.rule.mappings.length; j++) {
       if (data.rule.mappings[j].target.type === 'Topic Parameter') {
@@ -62,43 +62,43 @@ const fakeEventGenerator = async (data:any) => {
     }
   }
 
-  for (var i=0; i<data.count; i++) {
-    var topicParams:any = {};
-    var keys = Object.keys(data.rule.topicParameters);
-    for (var kl=0; kl<keys.length; kl++) {
-      let value = fakeDataValueGenerator({ rule: data.rule.topicParameters[keys[kl]].rule, count: 1});
+  for (let i=0; i<data.count; i++) {
+    const topicParams:any = {};
+    const keys = Object.keys(data.rule.topicParameters);
+    for (let kl=0; kl<keys.length; kl++) {
+      const value = fakeDataValueGenerator({ rule: data.rule.topicParameters[keys[kl]].rule, count: 1});
       topicParams[keys[kl]] = value ? value : '';
     }
     
-    var topic = data.rule.topic;
-    var topicValues:any = {};
+    let topic = data.rule.topic;
+    const topicValues:any = {};
     for (var j=0; j<keys.length; j++) {
       if (!mappedTopicParams.includes(keys[j]))
       topic = topic.replace(`{${keys[j]}}`, topicParams[keys[j]]);
       topicValues[`_${keys[j]}`] = topicParams[keys[j]];
     }
-    var payload = data.count > 1 ? payloads[i] : payloads;
+    const payload = data.count > 1 ? payloads[i] : payloads;
 
     // apply mapping
     if (data.rule.mappings && data.rule.mappings.length) {
       for (var j=0; j<data.rule.mappings.length; j++) {
-        var mapping = data.rule.mappings[j];
-        var sourceVal:any = undefined;
-        var target:any = undefined;
+        const mapping = data.rule.mappings[j];
+        let sourceVal:any = undefined;
+        let target:any = undefined;
 
         if (mapping.source.type === 'Payload Parameter') {
-          let sourceName = mapping.source.name.replaceAll('.properties', '').replaceAll('[]', '');
+          const sourceName = mapping.source.name.replaceAll('.properties', '').replaceAll('[]', '');
           sourceVal = getSourceFieldValue(payload, sourceName);
         } else {
           sourceVal = topicValues[`_${mapping.source.name}`];
         }
 
         if (mapping.target.type === 'Payload Parameter') {
-          let targetName = mapping.target.name.replaceAll('.properties', '').replaceAll('[]', '');
+          const targetName = mapping.target.name.replaceAll('.properties', '').replaceAll('[]', '');
           setTargetFieldValue(payload, targetName, sourceVal);
         } else {
           target = topicParams[mapping.target.name];          
-          for (var k=0; k<keys.length; k++) {
+          for (let k=0; k<keys.length; k++) {
             if (keys[k] === mapping.target.name) {
               if (mappedTopicParams.includes(keys[k]))
                 topic = topic.replace(`{${keys[k]}}`, sourceVal);
@@ -120,8 +120,8 @@ const fakeEventGenerator = async (data:any) => {
 }
 
 const fakeDataObjectGenerator = (data:any) => {
-  var fakeObjects: any[] | any = [];
-  var count = data.count ? data.count : 1;
+  let fakeObjects: any[] | any = [];
+  const count = data.count ? data.count : 1;
   if (data.payload.type === 'array') {
     if (data.payload.subType === 'object')
       fakeObjects = processObjectRules(data.payload.properties, count);
@@ -142,8 +142,8 @@ const fakeDataObjectGenerator = (data:any) => {
 }
 
 const fakeDataValueGenerator = (data:any) => {
-  var fakeData: any[] | any = [];
-  var count = data.count ? data.count : 1;
+  let fakeData: any[] | any = [];
+  const count = data.count ? data.count : 1;
   if (!data || !data.rule || !data.rule.group) {
     return;
   }

--- a/src/lib/feed-datarules.ts
+++ b/src/lib/feed-datarules.ts
@@ -3,9 +3,9 @@ import { fakeDataValueGenerator } from './feed-datahelper';
 import { parseBoolean } from '../utils/parse';
 
 export const processStringRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
-  var val:any = '';
+  const data: any[] = [];
+  let options:any = {};
+  let val:any = '';
   if (rule.rule === 'alpha') {
     options = {
       length: {
@@ -31,7 +31,7 @@ export const processStringRules = (rule:any, count:number) => {
       data.push(faker.string.alphanumeric(options));
     }
   } else if (rule.rule === 'enum') {
-    let enumObj:any = {};
+    const enumObj:any = {};
     let enumValue:any = {};
     rule.enum.forEach((t: string) => {
       enumObj[`'${t}'`] = t;
@@ -124,8 +124,8 @@ export const processStringRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processNullRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  const options:any = {};
 
   if (rule.rule === 'null') {
     for (var i=0; i<count; i++) {
@@ -139,8 +139,8 @@ export const processNullRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processNumberRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  let options:any = {};
   if (rule.rule === 'int') {
     options = {
       min: rule.minimum,
@@ -177,10 +177,10 @@ export const processNumberRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processBooleanRules = (rule:any, count:number) => {
-  var data: any[] = [];
+  const data: any[] = [];
 
   if (rule.rule === 'boolean') {
-    for (var i=0; i<count; i++) {
+    for (let i=0; i<count; i++) {
       data.push(faker.datatype.boolean());
     }
     
@@ -189,8 +189,8 @@ export const processBooleanRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processDateRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  let options:any = {};
 
   if (rule.rule === 'timeStamp') {
     for (var i=0; i<count; i++) {
@@ -211,14 +211,14 @@ export const processDateRules = (rule:any, count:number) => {
         data.push(`${day}-${month}-${year}`);
     }
   } else if (rule.rule === 'currentDateWithTime') {
-    let formatter = new Intl.DateTimeFormat("en-US", {
+    const formatter = new Intl.DateTimeFormat("en-US", {
       month: '2-digit',
       day: '2-digit',
       year: 'numeric',
     });
 
     for (var i=0; i<count; i++) {
-      let date = new Date();
+      const date = new Date();
       const [{ value: month }, , { value: day }, , { value: year }] = formatter.formatToParts(date);
 
       // Extract time components
@@ -238,7 +238,7 @@ export const processDateRules = (rule:any, count:number) => {
         data.push(`${day}-${month}-${year} ${hours12}:${minutes}:${seconds} ${amPm}`);
     }
   } else if (rule.rule === 'currentTime') {
-    let formatter = new Intl.DateTimeFormat("en-US", {
+    const formatter = new Intl.DateTimeFormat("en-US", {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
@@ -246,7 +246,7 @@ export const processDateRules = (rule:any, count:number) => {
     });
 
     for (var i=0; i<count; i++) {
-      let date = new Date();
+      const date = new Date();
       data.push(formatter.format(date));
     }
   } else if (rule.rule === 'anytime') {
@@ -306,8 +306,8 @@ export const processDateRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processLoremRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  let options:any = {};
 
   if (rule.rule === 'lines') {
     options = {
@@ -356,7 +356,7 @@ export const processLoremRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processPersonRules = (rule:any, count:number) => {
-  var data: any[] = [];
+  const data: any[] = [];
 
   if (rule.rule === 'prefix') {
     for (var i=0; i<count; i++) {
@@ -403,8 +403,8 @@ export const processPersonRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processLocationRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  let options:any = {};
 
   if (rule.rule === 'buildingNumber') {
     for (var i=0; i<count; i++) {
@@ -467,8 +467,8 @@ export const processLocationRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processFinanceRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  let options:any = {};
 
   if (rule.rule === 'accountNumber') {
     for (var i=0; i<count; i++) {
@@ -528,8 +528,8 @@ export const processFinanceRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processAirlineRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  let options:any = {};
 
   if (rule.rule === 'airline') {
     for (var i=0; i<count; i++) {
@@ -538,28 +538,28 @@ export const processAirlineRules = (rule:any, count:number) => {
   } else if (rule.rule === 'airplane') {
     for (var i=0; i<count; i++) {
       data.push(() => {
-        let ap = faker.airline.airplane();
+        const ap = faker.airline.airplane();
         return `${ap.name} [${ap.iataTypeCode}]`
       });
     }
   } else if (rule.rule === 'airport') {
     for (var i=0; i<count; i++) {
       data.push(() => {
-        let ap = faker.airline.airport();
+        const ap = faker.airline.airport();
         return `${ap.name} [${ap.iataCode}]`
       });
     }
   } else if (rule.rule === 'airportName') {
     for (var i=0; i<count; i++) {
       data.push(() => {
-        let ap = faker.airline.airport();
+        const ap = faker.airline.airport();
         return ap.name;
       });
     }
   } else if (rule.rule === 'airportCode') {
     for (var i=0; i<count; i++) {
       data.push(() => {
-        let ap = faker.airline.airport();
+        const ap = faker.airline.airport();
         return ap.iataCode;
       });
     }
@@ -580,8 +580,8 @@ export const processAirlineRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processCommerceRules = (rule:any, count:number) => {
-  var data: any[] = [];
-  var options:any = {};
+  const data: any[] = [];
+  let options:any = {};
 
   if (rule.rule === 'companyName') {
     for (var i=0; i<count; i++) {
@@ -621,20 +621,20 @@ export const processCommerceRules = (rule:any, count:number) => {
   return count === 1 ? data[0] : data;
 }
 export const processInternetRules = (rule:any, count:number) => {
-  var data: any[] = [];
+  const data: any[] = [];
   if (rule.rule === 'domainName') {
     for (var i=0; i<count; i++) {
-      let value = faker.internet.domainName();
+      const value = faker.internet.domainName();
       data.push(rule.casing === 'mixed' ? value : rule.casing === 'upper' ? value.toUpperCase() : value.toLowerCase());
     }
   } else if (rule.rule === 'domainWord') {
     for (var i=0; i<count; i++) {
-      let value = faker.internet.domainWord();
+      const value = faker.internet.domainWord();
       data.push(rule.casing === 'mixed' ? value : rule.casing === 'upper' ? value.toUpperCase() : value.toLowerCase());
     }
   } else if (rule.rule === 'email') {
     for (var i=0; i<count; i++) {
-      let value = faker.internet.email();
+      const value = faker.internet.email();
       data.push(rule.casing === 'mixed' ? value : rule.casing === 'upper' ? value.toUpperCase() : value.toLowerCase());
     }
   } else if (rule.rule === 'emoji') {
@@ -655,12 +655,12 @@ export const processInternetRules = (rule:any, count:number) => {
     }
   } else if (rule.rule === 'url') {
     for (var i=0; i<count; i++) {
-      let value = faker.internet.url();
+      const value = faker.internet.url();
       data.push(rule.casing === 'mixed' ? value : rule.casing === 'upper' ? value.toUpperCase() : value.toLowerCase());
     }
   } else if (rule.rule === 'username') {
     for (var i=0; i<count; i++) {
-      let value = faker.internet.userName();
+      const value = faker.internet.userName();
       data.push(rule.casing === 'mixed' ? value : rule.casing === 'upper' ? value.toUpperCase() : value.toLowerCase());
     }
   }
@@ -669,8 +669,8 @@ export const processInternetRules = (rule:any, count:number) => {
 }
 
 const generateObject = (obj:any) => {
-  var data:any = {};
-  var keys = Object.keys(obj ? obj : {});
+  const data:any = {};
+  const keys = Object.keys(obj ? obj : {});
   keys.forEach(key => {
     if (obj[key].type === 'object')
       data[key] = generateObject(obj[key].properties);
@@ -679,7 +679,7 @@ const generateObject = (obj:any) => {
     else if (typeof obj[key] === 'object' && !Object.keys(obj[key]).length)
       data[key] = {}; // empty object (should we consider undefined!!)
     else {
-      let value = fakeDataValueGenerator(obj[key]);
+      const value = fakeDataValueGenerator(obj[key]);
       // if (!value && obj[key].rule.rule === 'null') {
       data[key] = value;
     }
@@ -689,9 +689,9 @@ const generateObject = (obj:any) => {
 }
 
 export const processObjectRules = (payload:any, count:number) => {
-  var data: any[] = [];
+  const data: any[] = [];
 
-  for (var i=0; i<count; i++) {
+  for (let i=0; i<count; i++) {
     data.push(generateObject(payload));
   }
 
@@ -699,9 +699,9 @@ export const processObjectRules = (payload:any, count:number) => {
 }
 
 export const processBaseObjectRules = (payload:any, count:number) => {
-  var data: any[] = [];
+  const data: any[] = [];
 
-  for (var i=0; i<count; i++) {
+  for (let i=0; i<count; i++) {
     data.push(fakeDataValueGenerator(payload));
   }
 
@@ -709,11 +709,11 @@ export const processBaseObjectRules = (payload:any, count:number) => {
 }
 
 const generateArray = (obj:any) => {
-  var data:any = [];
+  const data:any = [];
   if (obj.items && Object.keys(obj.items).length === 0)
     return data;
-  var count = obj.rule.count ? obj.rule.count : 1;
-  for (var i=0; i<count; i++) {
+  const count = obj.rule.count ? obj.rule.count : 1;
+  for (let i=0; i<count; i++) {
     if (obj.subType === 'object')
       data.push(generateObject(obj?.items?.properties ? obj.items.properties : obj.properties));
     else if (obj.subType === 'array')

--- a/src/lib/feed-export.ts
+++ b/src/lib/feed-export.ts
@@ -8,8 +8,8 @@ const IMPORTER_URL = 'https://ep-asyncapi-importer.cfapps.ca10.hana.ondemand.com
 const epExport = async (options: ManageFeedClientOptions, optionsSource: any) => {
   const cloudSettings:any = {};
 
-  var feedName = '';
-  var gitFeed = undefined;
+  let feedName = '';
+  let gitFeed = undefined;
 
   const startLoadingSimulator = (message:string, interval: number) => {
     let dots = 0;
@@ -137,7 +137,7 @@ const epExport = async (options: ManageFeedClientOptions, optionsSource: any) =>
       ]
     });
 
-    var choice = undefined;
+    let choice = undefined;
     await pFeedSource.run()
       .then((answer: any) => { choice = answer; })
       .catch((error:any) => {
@@ -218,7 +218,7 @@ const epExport = async (options: ManageFeedClientOptions, optionsSource: any) =>
   }
 
   // load feed details
-  let analysis = gitFeed ? await loadGitFeedFile(feedName, defaultFeedAnalysisFile) : 
+  const analysis = gitFeed ? await loadGitFeedFile(feedName, defaultFeedAnalysisFile) : 
                             await loadLocalFeedFile(feedName, defaultFeedAnalysisFile);
   if (!analysis) {
     Logger.logError('error loading feed details...')
@@ -226,7 +226,7 @@ const epExport = async (options: ManageFeedClientOptions, optionsSource: any) =>
   }
 
   cloudSettings.specFile = analysis.fileName;
-  let spec = gitFeed ? await loadGitFeedFile(feedName, analysis.fileName) :
+  const spec = gitFeed ? await loadGitFeedFile(feedName, analysis.fileName) :
                       await loadLocalFeedFile(feedName, analysis.fileName);
   if (!spec) {
     Logger.logError('error loading AsyncAPI document...')
@@ -298,7 +298,7 @@ const epExport = async (options: ManageFeedClientOptions, optionsSource: any) =>
     
     await pDomainSelection.run()
       .then((answer:any) => {
-        var domain = domains.find((d:any) => d.name === answer);
+        const domain = domains.find((d:any) => d.name === answer);
         cloudSettings.domainName = domain.name;
         cloudSettings.domainId = domain.id;
       })

--- a/src/lib/feed-generate.ts
+++ b/src/lib/feed-generate.ts
@@ -14,8 +14,8 @@ import { enhanceFeedrulesWithAI } from '../utils/field-mapper-client';
 import { hasAcceptedAiDisclaimer, showAiDisclaimer, recordAiDisclaimerAcceptance } from '../utils/ai-disclaimer';
 
 const generate = async (options: ManageFeedClientOptions, optionsSource: any) => {
-  var { fileName, feedName, feedType, feedView } = options;
-  var feed:any = {
+  let { fileName, feedName, feedType, feedView } = options;
+  const feed:any = {
     version: `${defaultFeedMajorVersion}.${defaultFeedMinorVersion}`,
   };
   const { Input } = require('enquirer');
@@ -309,9 +309,9 @@ const generate = async (options: ManageFeedClientOptions, optionsSource: any) =>
 }
 
 const generateAPIFeed = async (options: ManageFeedClientOptions, optionsSource: any) => {
-  var { feedName } = options;
-  var feed:any = { type: 'restapi_feed', name: feedName };
-  var apiRules:any = {
+  const { feedName } = options;
+  let feed:any = { type: 'restapi_feed', name: feedName };
+  let apiRules:any = {
     publishSettings: {
       "count": 0,
       "interval": 1000,
@@ -319,10 +319,10 @@ const generateAPIFeed = async (options: ManageFeedClientOptions, optionsSource: 
     }
   }
 
-  var apiSession:any = sessionPropertiesJson;
+  let apiSession:any = sessionPropertiesJson;
 
-  var apiEndpoint:any = {};
-  var localFeedPath = '';
+  let apiEndpoint:any = {};
+  let localFeedPath = '';
   
   const { Input, Select, Confirm } = require('enquirer');
 
@@ -491,11 +491,11 @@ const generateAPIFeed = async (options: ManageFeedClientOptions, optionsSource: 
         process.exit(1);
       });
   } else if (apiEndpoint.apiAuthType === 'X-API Authentication') {
-    var newPairs = [];
-    var xapiPairs = apiEndpoint?.xapiPairs ? apiEndpoint?.xapiPairs : [];
-    var pair = 0;
-    var done = false;
-    var restart = false;
+    const newPairs = [];
+    const xapiPairs = apiEndpoint?.xapiPairs ? apiEndpoint?.xapiPairs : [];
+    let pair = 0;
+    let done = false;
+    let restart = false;
     do {
       restart = false;
       var xApiPair = { 
@@ -556,19 +556,19 @@ const generateAPIFeed = async (options: ManageFeedClientOptions, optionsSource: 
   } else {
     // check if the API endpoint is valid
     try {
-      var headers:any = { Accept: 'application/json' };
+      const headers:any = { Accept: 'application/json' };
       if (apiEndpoint.apiAuthType === 'Basic Authentication') {
         headers['Authorization'] = `Basic ${apiEndpoint.apiToken}`;
       } else if (apiEndpoint.apiAuthType === 'Token Authentication') {
         headers['Authorization'] = `Bearer ${apiEndpoint.apiToken}`;
       } else if (apiEndpoint.apiAuthType === 'X-API Authentication') {
         for (var i=0; i<apiEndpoint.xapiPairs.length; i++) {
-          var xPair = apiEndpoint.xapiPairs[i];
+          const xPair = apiEndpoint.xapiPairs[i];
           headers[xPair.key] = xPair.value;
         }
       }
 
-      var result = await (await fetch(`${apiEndpoint.apiUrl}`, {
+      const result = await (await fetch(`${apiEndpoint.apiUrl}`, {
         headers: headers
       })).json();
       Logger.logInfo('Testing API endpoint');
@@ -592,17 +592,17 @@ const generateAPIFeed = async (options: ManageFeedClientOptions, optionsSource: 
 
   await pTopic.run()
     .then((answer: string) => {
-      var topic = answer.trim();      
+      const topic = answer.trim();      
       apiEndpoint.topic = topic.split('/').join('/');
       if (apiEndpoint.topic.includes('$')) {
-        var topicParams = apiEndpoint.topic.split('/').filter((t:any) => t.startsWith('$'));
-        var apiUrl = new URL(apiEndpoint.apiUrl);
-        var apiParams = apiUrl.pathname.split('/').filter((t:any) => t.startsWith('$'));
+        const topicParams = apiEndpoint.topic.split('/').filter((t:any) => t.startsWith('$'));
+        const apiUrl = new URL(apiEndpoint.apiUrl);
+        const apiParams = apiUrl.pathname.split('/').filter((t:any) => t.startsWith('$'));
         for (const [key, value] of apiUrl.searchParams)
           apiParams.push(value);
 
-        for (var i=0; i<topicParams.length; i++) {
-          var p:string = topicParams[i];
+        for (let i=0; i<topicParams.length; i++) {
+          const p:string = topicParams[i];
           if (!apiParams.includes(p)) {
             Logger.logDetailedError('Specified topic parameter not found in the URL parameters', chalkBoldVariable(p));
             Logger.success('exiting...');
@@ -766,8 +766,8 @@ const generateAPIFeed = async (options: ManageFeedClientOptions, optionsSource: 
 
   const rules:any = {};
   if (apiEndpoint.apiUrl.includes('$') || apiEndpoint.apiUrl.includes('{')) {
-    var apiUrl = new URL(apiEndpoint.apiUrl);
-    var params = apiUrl.pathname.split('/').filter((t:any) => t.startsWith('$')).map((t:any) => t.substring(1, t.length));
+    const apiUrl = new URL(apiEndpoint.apiUrl);
+    const params = apiUrl.pathname.split('/').filter((t:any) => t.startsWith('$')).map((t:any) => t.substring(1, t.length));
     for (var i=0; i<params.length; i++) {
       var p:string = params[i];
       if (apiEndpoint.apiKeyUrlEmbedded && p === apiEndpoint.apiKeyUrlParam)
@@ -815,7 +815,7 @@ const generateAPIFeed = async (options: ManageFeedClientOptions, optionsSource: 
     }    
   }
 
-  var feedRule = {
+  const feedRule = {
     rules: rules,
     publishSettings: apiRules.publishSettings
   }
@@ -835,9 +835,9 @@ const checkEventValidity = async (data:any) => {
   let noOfReceiveEvents = 0;
 
   Object.keys(data.messages).forEach((messageName) => {
-    var sendEvents = data.messages[messageName].send;
+    const sendEvents = data.messages[messageName].send;
     noOfSendEvents += sendEvents.length;
-    var receiveEvents = data.messages[messageName].receive;
+    const receiveEvents = data.messages[messageName].receive;
     noOfReceiveEvents += receiveEvents.length;
   });
 

--- a/src/lib/feed-import.ts
+++ b/src/lib/feed-import.ts
@@ -6,7 +6,7 @@ import { fileExists, processPlainPath } from '../utils/config';
 import { defaultStmFeedsHome } from '../utils/defaults';
 
 const feedImport = async (options: ManageFeedClientOptions, optionsSource: any) => {
-  var archiveFile = optionsSource.archiveFile === 'cli' ? options.archiveFile : '';
+  let archiveFile = optionsSource.archiveFile === 'cli' ? options.archiveFile : '';
 
   if (!archiveFile) {
     const { Input } = require('enquirer');
@@ -25,7 +25,7 @@ const feedImport = async (options: ManageFeedClientOptions, optionsSource: any) 
   }
 
   archiveFile = archiveFile.trim().replace(/['"]+/g, '');
-  let zipPath = !fileExists(archiveFile) ? `${process.cwd()}/${archiveFile}` : archiveFile;
+  const zipPath = !fileExists(archiveFile) ? `${process.cwd()}/${archiveFile}` : archiveFile;
   if (!fileExists(zipPath)) {
     Logger.logError(`File ${archiveFile} does not exist!`);
     Logger.error('exiting...');
@@ -38,7 +38,7 @@ const feedImport = async (options: ManageFeedClientOptions, optionsSource: any) 
     process.exit(1)
   }
 
-  var importPath = `${process.cwd()}/import`;
+  const importPath = `${process.cwd()}/import`;
   if (fileExists(importPath)) fs.rmdirSync(importPath, { recursive: true });
   fs.mkdirSync(importPath, { recursive: true });
 

--- a/src/lib/feed-list.ts
+++ b/src/lib/feed-list.ts
@@ -13,12 +13,12 @@ const wordwrap = (str:any, width:any, brk:any, cut:any ) => {
 
   if (!str) { return str; }
 
-  var regex = '.{1,' +width+ '}(\s|$)' + (cut ? '|.{' +width+ '}|.+$' : '|\S+?(\s|$)');
+  const regex = '.{1,' +width+ '}(\s|$)' + (cut ? '|.{' +width+ '}|.+$' : '|\S+?(\s|$)');
   return str.match( RegExp(regex, 'g') ).join( brk );
 }
 
 const list = async (options: ManageFeedClientOptions, optionsSource: any) => {
-  var communityOnly, localOnly = false;
+  let communityOnly, localOnly = false;
 
   if (options.lint) {
     Logger.logSuccess('linting successful...')
@@ -58,14 +58,14 @@ const list = async (options: ManageFeedClientOptions, optionsSource: any) => {
 
   const feedPath = processPlainPath(`${defaultStmFeedsHome}`);
 
-  var localFeeds: any[] = [];
+  const localFeeds: any[] = [];
   if (localOnly) {
     const files:any = fs.readdirSync(`${feedPath}`);
     files.forEach((fileName: string) => {
-      var filePath = `${feedPath}/${fileName}`
-      var stat = fs.lstatSync(filePath);
+      const filePath = `${feedPath}/${fileName}`
+      const stat = fs.lstatSync(filePath);
       if (stat.isDirectory() && fs.existsSync(`${filePath}/${defaultFeedInfoFile}`)) {
-        var info = readFile(`${filePath}/${defaultFeedInfoFile}`);
+        const info = readFile(`${filePath}/${defaultFeedInfoFile}`);
         localFeeds.push(info);
       }
     })
@@ -80,7 +80,7 @@ const list = async (options: ManageFeedClientOptions, optionsSource: any) => {
     }
   }
   
-  var result:any = [];
+  let result:any = [];
   if (localFeeds.length) {
     Logger.await('Fetching Local Event Feeds...');
     Logger.logSuccess(`Local Event Feeds: ${localFeeds.length}`);

--- a/src/lib/feed-portal.ts
+++ b/src/lib/feed-portal.ts
@@ -7,7 +7,7 @@ import { getGitEventFeeds } from '../utils/listfeeds';
 
 const feedPortal = async (options: ManageFeedClientOptions, optionsSource: any) => {
   const managePort = options.managePort ? options.managePort : 0;
-  var publicDir = __dirname.substring(0, __dirname.lastIndexOf(defaultProjectName) + defaultProjectName.length);
+  const publicDir = __dirname.substring(0, __dirname.lastIndexOf(defaultProjectName) + defaultProjectName.length);
 
   const express = require('express');
   const app = express();
@@ -25,35 +25,35 @@ const feedPortal = async (options: ManageFeedClientOptions, optionsSource: any) 
   
   app.post('/feeds', async (req:any, res:any) => {
     const isLocal = req.query?.isLocal === true || req.query?.isLocal === 'true';
-    var localFeeds: any[] = [];
+    const localFeeds: any[] = [];
     if (isLocal) {
       const files:any = fs.readdirSync(`${defaultStmFeedsHome}`);
       const feedPath = processPlainPath(`${defaultStmFeedsHome}`);
       files.forEach((fileName: string) => {
-        var filePath = `${feedPath}/${fileName}`
-        var stat = fs.lstatSync(filePath);
+        const filePath = `${feedPath}/${fileName}`
+        const stat = fs.lstatSync(filePath);
         if (stat.isDirectory() && fs.existsSync(`${filePath}/${defaultFeedInfoFile}`)) {
-          var info = readFile(`${filePath}/${defaultFeedInfoFile}`);
+          const info = readFile(`${filePath}/${defaultFeedInfoFile}`);
           localFeeds.push(info);
         }
       })
     }
 
-    var communityFeeds = await getGitEventFeeds();
+    const communityFeeds = await getGitEventFeeds();
 
     res.send({localFeeds, communityFeeds});
   });
 
   app.post('/localfeed', async (req:any, res:any) => {
-    var feed = req.body;
+    const feed = req.body;
     const files:any = fs.readdirSync(`${defaultStmFeedsHome}`);
     const feedPath = processPlainPath(`${defaultStmFeedsHome}`);
-    var found = false;
+    let found = false;
     files.forEach((fileName: string) => {
       if (fileName === feed.feedName) {
-        var filePath = `${feedPath}/${fileName}/${feed.fileName}`
+        const filePath = `${feedPath}/${fileName}/${feed.fileName}`
         if (fs.existsSync(`${filePath}`)) {
-          var content = readFile(`${filePath}`);
+          const content = readFile(`${filePath}`);
           res.send({content});
           found = true;
           return;
@@ -114,10 +114,10 @@ const feedPortal = async (options: ManageFeedClientOptions, optionsSource: any) 
     // console.log(`Server is running on http://127.0.0.1:8081`);
   });
 
-  let http = require('http');
-  let server = http.createServer(app);
+  const http = require('http');
+  const server = http.createServer(app);
   server.listen(managePort, () => {
-    var opener = require("opener");
+    const opener = require("opener");
     Logger.info(`Accessible at http://127.0.0.1:8081`);
     opener(`http://127.0.0.1:8081`)
   });

--- a/src/lib/feed-preview.ts
+++ b/src/lib/feed-preview.ts
@@ -7,7 +7,7 @@ import { analyze, analyzeEP, analyzeV2, load } from './feed-analyze';
 import { AsyncAPIDocumentInterface } from '@asyncapi/parser';
 
 const preview = async (options: ManageFeedClientOptions, optionsSource: any) => {
-  var feedName, fileName, feedView, gitFeed = undefined;
+  let feedName, fileName, feedView, gitFeed = undefined;
 
   if (optionsSource.feedName === 'cli' || optionsSource.fileName === 'cli') {
     feedName = options.feedName;
@@ -28,7 +28,7 @@ const preview = async (options: ManageFeedClientOptions, optionsSource: any) => 
       ]
     });
 
-    var choice = undefined;
+    let choice = undefined;
     await pFeedSource.run()
       .then((answer: any) => { choice = answer; })
       .catch((error:any) => {
@@ -134,9 +134,9 @@ const preview = async (options: ManageFeedClientOptions, optionsSource: any) => 
   }
 
   const reverseView = feedView === 'provider';
-  var data:any = undefined;
-  var info:any = undefined;
-  var type:any = undefined;
+  let data:any = undefined;
+  let info:any = undefined;
+  let type:any = undefined;
   if (fileName) {
     const asyncApiSchema = readAsyncAPIFile(fileName);  
     const loaded:any = await load(asyncApiSchema);
@@ -169,7 +169,7 @@ const preview = async (options: ManageFeedClientOptions, optionsSource: any) => 
     process.exit(1);
   }
 
-  var result:any = [];
+  const result:any = [];
   let noOfSendEvents = 0;
   let noOfReceiveEvents = 0;
   if (type === 'file' || type === 'asyncapi_feed') {
@@ -182,7 +182,7 @@ const preview = async (options: ManageFeedClientOptions, optionsSource: any) => 
 
     let sendAdded = false;
     Object.keys(data.messages).forEach((messageName) => {
-      var sendEvents = data.messages[messageName].send;
+      const sendEvents = data.messages[messageName].send;
       noOfSendEvents += sendEvents.length;
       if (sendEvents.length) {
         if (!sendAdded) {
@@ -219,7 +219,7 @@ const preview = async (options: ManageFeedClientOptions, optionsSource: any) => 
     
     let receiveAdded = false;
     Object.keys(data.messages).forEach((messageName) => {
-      var receiveEvents = data.messages[messageName].receive;
+      const receiveEvents = data.messages[messageName].receive;
       noOfReceiveEvents += receiveEvents.length;
       if (receiveEvents.length) {
         if (!receiveAdded) {
@@ -277,7 +277,7 @@ const preview = async (options: ManageFeedClientOptions, optionsSource: any) => 
         schemaAdded = true;
       }
 
-      let _schema = data.schemas[schemaName]
+      const _schema = data.schemas[schemaName]
       result.push(chalkBoldLabel('│   ├──Schema: ') + chalkBoldWhite(schemaName))
       _schema.description &&
         result.push(chalkBoldLabel('│   │   │      ') + 

--- a/src/lib/feed-ruleset.ts
+++ b/src/lib/feed-ruleset.ts
@@ -9,7 +9,7 @@ const removeMetaParams = (obj: any) => {
 
 const setDefaultTopicVariableRules = (obj: any) => {
   for(const prop in obj) {
-    var schema = obj[prop].schema;
+    let schema = obj[prop].schema;
     schema = !schema || !schema.type ? { type: 'string' } : schema;
     if (schema.type.toLowerCase() === 'string') {
       obj[prop].rule = { name: prop, type: 'string', group: 'StringRules', rule: 'alpha', casing: 'mixed', minLength: 10, maxLength: 10 }
@@ -29,7 +29,7 @@ const setDefaultTopicVariableRules = (obj: any) => {
 
 const setDefaultSchemaRules = (msgs: any) => {
   msgs.forEach((msg:any) => {
-    var payload = msg.payload;
+    const payload = msg.payload;
     if (!payload) return;
 
     processPayload(msg);
@@ -37,7 +37,7 @@ const setDefaultSchemaRules = (msgs: any) => {
 }
 
 const processPayload = (msg: any) => {
-  var payload = msg.payload;
+  let payload = msg.payload;
   payload = payload ? payload : msg.properties;
   if (!payload) return;
 
@@ -65,7 +65,7 @@ const processPayload = (msg: any) => {
       continue;
     }
 
-    var schema = payload[prop];
+    const schema = payload[prop];
     if (schema.type.toLowerCase() === 'string') {
       if (schema.enum) {
         payload[prop].rule = { ...payload[prop], name: prop, type: 'string', group: 'StringRules', rule: 'enum', enum: schema.enum }
@@ -87,13 +87,13 @@ const processPayload = (msg: any) => {
 }
 
 const formulateRules = async (data: any) => {
-  var ruleSet:any = [];
-  var msgNames = Object.keys(data.messages);
+  const ruleSet:any = [];
+  const msgNames = Object.keys(data.messages);
   msgNames.forEach((msgName) => {    
-    var message = data.messages[msgName];
+    const message = data.messages[msgName];
     if (message.send.length) {
       message.send.forEach((send: any) => {
-        var topic:any = {};
+        const topic:any = {};
         topic.topic = send.topicName;
         topic.eventName = send.message['x-ep-event-name'];
         topic.eventVersion = send.message['x-ep-event-version'];
@@ -119,13 +119,13 @@ const formulateRules = async (data: any) => {
 }
 
 const formulateSchemas = async (data: any) => {
-  var schemaSet:any = [];
-  var msgNames = Object.keys(data.messages);
+  const schemaSet:any = [];
+  const msgNames = Object.keys(data.messages);
   msgNames.forEach((msgName) => {    
-    var message = data.messages[msgName];
+    const message = data.messages[msgName];
     if (message.receive.length) {
       message.receive.forEach((receive: any) => {
-        var schema:any = {};
+        const schema:any = {};
         schema.topic = receive.topicName;
         schema.eventName = receive.message['x-ep-event-name'];
         schema.eventVersion = receive.message['x-ep-event-version'];

--- a/src/lib/feed-run-api.ts
+++ b/src/lib/feed-run-api.ts
@@ -21,7 +21,7 @@ const feedRunApi = async (options: ManageFeedPublishOptions, optionsSource: any)
   }
 
   const publisher = new SolaceClient(options);
-  var interrupted = false;
+  let interrupted = false;
   try {
     await publisher.connect()
   } catch (error:any) {
@@ -45,10 +45,10 @@ const feedRunApi = async (options: ManageFeedPublishOptions, optionsSource: any)
     }, options.exitAfter * 1000);
   }
 
-  var apiFeed = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedApiEndpointFile) : await loadLocalFeedFile(options.feedName, defaultFeedApiEndpointFile);
-  var apiFeedInfo = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedInfoFile) : await loadLocalFeedFile(options.feedName, defaultFeedInfoFile);
-  var apiFeedRule = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedRulesFile) : await loadLocalFeedFile(options.feedName, defaultFeedRulesFile);
-  var apiFeedSession = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedSessionFile) : await loadLocalFeedFile(options.feedName, defaultFeedSessionFile);
+  const apiFeed = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedApiEndpointFile) : await loadLocalFeedFile(options.feedName, defaultFeedApiEndpointFile);
+  const apiFeedInfo = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedInfoFile) : await loadLocalFeedFile(options.feedName, defaultFeedInfoFile);
+  const apiFeedRule = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedRulesFile) : await loadLocalFeedFile(options.feedName, defaultFeedRulesFile);
+  const apiFeedSession = options.communityFeed ? await loadGitFeedFile(options.feedName, defaultFeedSessionFile) : await loadLocalFeedFile(options.feedName, defaultFeedSessionFile);
   
   if (apiFeed.apiUrl.includes('$') && !apiFeedRule) {
     Logger.logError('api endpoint contains placeholders, please configure parameter rules...')
@@ -74,13 +74,13 @@ const feedRunApi = async (options: ManageFeedPublishOptions, optionsSource: any)
     published: 0
   });
 
-  for (var i=0; i<selectedEndpoints.length; i++) {
-    var endpoint = selectedEndpoints[i];
+  for (let i=0; i<selectedEndpoints.length; i++) {
+    const endpoint = selectedEndpoints[i];
     addEventFeedTimer(endpoint, publisher);
   }
 
   setInterval(() => {
-    var completed = selectedEndpoints.length;
+    let completed = selectedEndpoints.length;
     eventFeedTimers.forEach((t) => {
       if (t.completed && t.published >= publishStats[`${t.api.topic}`]) {
         completed--;
@@ -116,13 +116,13 @@ async function publishFeed(publisher:any, feed:any) {
   }
   
   try {
-    var headers:any = { Accept: 'application/json' };
+    const headers:any = { Accept: 'application/json' };
 
-    var apiUrl = feed.api.apiUrl;
-    var apiKey = feed.api.apiKey;
-    var apiToken = feed.api.apiToken;
-    var xapiPairs = feed.api.xapiPairs;
-    var apiRules = feed.rule.rules;
+    let apiUrl = feed.api.apiUrl;
+    const apiKey = feed.api.apiKey;
+    const apiToken = feed.api.apiToken;
+    const xapiPairs = feed.api.xapiPairs;
+    const apiRules = feed.rule.rules;
 
     if (feed.api.apiAuthType === 'Basic Authentication') {
       headers['Authorization'] = `Basic ${apiToken}`;
@@ -130,7 +130,7 @@ async function publishFeed(publisher:any, feed:any) {
       headers['Authorization'] = `Bearer ${apiToken}`;
     } else if (feed.api.apiAuthType === 'X-API Authentication') {
       for (var i=0; i<xapiPairs.length; i++) {
-        var xPair = xapiPairs[i];
+        const xPair = xapiPairs[i];
         headers[xPair.key] = xPair.value;
       }
     } else if (feed.api.apiAuthType === 'API Key' && !feed.api.apiKeyUrlEmbedded) {
@@ -139,23 +139,23 @@ async function publishFeed(publisher:any, feed:any) {
       apiUrl = apiUrl.replaceAll(`$${feed.api.apiKeyUrlParam}`, apiKey);
     }
 
-    var params = Object.keys(apiRules);
-    var ruleData:any = {};
+    const params = Object.keys(apiRules);
+    const ruleData:any = {};
     if (params.length > 0) {
       for (var i=0; i<params.length; i++) {
         ruleData[params[i]] = await fakeDataValueGenerator({rule: apiRules[params[i]].rule, count: 1});
       }
     }
   
-    var topic = feed.api.topic;
-    var url = apiUrl;
-    for (var j=0; j<params.length; j++) {
+    let topic = feed.api.topic;
+    let url = apiUrl;
+    for (let j=0; j<params.length; j++) {
       url = url.replaceAll(`$${params[j]}`, ruleData[params[j]]);
       topic = topic.replaceAll(`$${params[j]}`, ruleData[params[j]]);
     }
 
     (async () => {
-      var payload = await (await fetch(`${url}`, {
+      const payload = await (await fetch(`${url}`, {
         headers: headers
       })).json();
 
@@ -169,7 +169,7 @@ async function publishFeed(publisher:any, feed:any) {
       publishStats[`${feed.api.topic}`]++;
       Logger.info(chalkEventCounterValue(publishStats[`${feed.api.topic}`]) + ' ' +  chalkEventCounterLabel(feed.name));
       if (feed.count > 0 && publishStats[`${feed.api.topic}`] >= feed.count) {
-        var index = eventFeedTimers.findIndex((t) => t.name === feed.name);
+        const index = eventFeedTimers.findIndex((t) => t.name === feed.name);
         if (index < 0) {
           console.error('Hmm... could not find the timer');
           return;

--- a/src/lib/feed-run.ts
+++ b/src/lib/feed-run.ts
@@ -18,9 +18,9 @@ const publishStats:any = {};
 
 const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) => {
   const { helpExamples, quiet } = options
-  var feedName: string = '';
-  var eventNames: string[] = [];
-  var gitFeed = false;
+  let feedName: string = '';
+  let eventNames: string[] = [];
+  let gitFeed = false;
 
   if (helpExamples) {
     // TODO
@@ -29,7 +29,7 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
 
   checkFeedRunOptions(options, optionsSource);
 
-  var cmdLine = false;
+  let cmdLine = false;
   if (options.useDefaults) {
     cmdLine = true;
     var feedInfo = await loadLocalFeedFile(options.feedName, defaultFeedInfoFile);
@@ -176,7 +176,7 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
       ]
     });
 
-    var choice = undefined;
+    let choice = undefined;
     await pFeedSource.run()
       .then((answer: any) => { choice = answer; })
       .catch((error:any) => {
@@ -312,7 +312,7 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
     }
     
     if (optionsSource.eventNames === 'cli') {
-      var foundEvents = events.filter((el:any) => options.eventNames.find((e:any) => el.name === e));
+      const foundEvents = events.filter((el:any) => options.eventNames.find((e:any) => el.name === e));
 
       options.eventNames = [];
       foundEvents.map((event:any) => {
@@ -334,11 +334,11 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
   }
 
   // load feed rules
-  var feed = gitFeed ? await loadGitFeedFile(feedName, defaultFeedRulesFile) : loadLocalFeedFile(feedName, defaultFeedRulesFile);
+  const feed = gitFeed ? await loadGitFeedFile(feedName, defaultFeedRulesFile) : loadLocalFeedFile(feedName, defaultFeedRulesFile);
 
   function fixSessionSettings(sessionSettings: any, property: string, options: any, optionName: any = null) {
     if (sessionSettings[property] !== undefined && sessionSettings[property].exposed && sessionSettings[property].value !== undefined) {
-      let optionProperty = optionName ? optionName : property;
+      const optionProperty = optionName ? optionName : property;
       options[optionProperty] = sessionSettings[property].value !== undefined ? 
                                   sessionSettings[property].value : sessionSettings[property].default;
       if (sessionSettings[property].datatype === 'number') {
@@ -350,7 +350,7 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
   }
 
   // populate feed settings (session and message)
-  var sessionSettings:any = null;
+  let sessionSettings:any = null;
   try {
     sessionSettings = gitFeed ? await loadGitFeedSessionFile(feedName, defaultFeedSessionFile) : 
                               loadLocalFeedSessionFile(feedName, defaultFeedSessionFile);
@@ -378,9 +378,9 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
 
   options.readyForExit = options.eventNames.length;
   options.eventNames.forEach((eventName:any) => {
-    var feedRule:any = undefined;
-    var name = eventName.split('      ')[0];
-    var topic = eventName.split('      ')[1];
+    let feedRule:any = undefined;
+    const name = eventName.split('      ')[0];
+    const topic = eventName.split('      ')[1];
     feed.forEach((rule:any) => {
       if (rule.messageName === name && rule.topic === topic) {
         feedRule = rule;
@@ -392,7 +392,7 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
       return;
     }
 
-    let publishInterval = optionsSource.interval === 'cli' ? options.interval :
+    const publishInterval = optionsSource.interval === 'cli' ? options.interval :
                             feedRule.publishSettings?.hasOwnProperty('interval') ? 
                               parseInt(feedRule.publishSettings?.interval) : defaultMessagePublishConfig.interval;
 
@@ -430,7 +430,7 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
   });
 
   const publisher = new SolaceClient(options);
-  var interrupted = false;
+  let interrupted = false;
   try {
     await publisher.connect()
   } catch (error:any) {
@@ -454,13 +454,13 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
     }, options.exitAfter * 1000);
   }
 
-  for (var i=0; i<selectedMessages.length; i++) {
-    var msg = selectedMessages[i];
+  for (let i=0; i<selectedMessages.length; i++) {
+    const msg = selectedMessages[i];
     addEventFeedTimer({...msg}, publisher);
   }
 
   setInterval(() => {
-    var completed = selectedMessages.length;
+    let completed = selectedMessages.length;
     eventFeedTimers.forEach((t) => {
       if (t.completed && t.message.count >= publishStats[`${t.message.message}-${t.message.topic}`]) {
         completed--;
@@ -490,7 +490,7 @@ const feedRun = async (options: ManageFeedPublishOptions, optionsSource: any) =>
 
 function fixDefaultMessageSettings(defaultSettings: any, property: string, options: any, optionName: any = null) {
   if (defaultSettings[property] !== undefined && defaultSettings[property].exposed) {
-    let optionProperty = optionName ? optionName : property;
+    const optionProperty = optionName ? optionName : property;
     options[optionProperty] = defaultSettings[optionProperty].default;
     if (defaultSettings[property].datatype === 'number') {
       options[optionProperty] = parseInt(options[optionProperty]);
@@ -504,7 +504,7 @@ function fixDefaultMessageSettings(defaultSettings: any, property: string, optio
 
 function fixMessageSettings(defaultSettings: any, messageSettings: any, property: string, options: any, optionName: any = null) {
   if (defaultSettings[property] !== undefined && defaultSettings[property].exposed && messageSettings[property] !== undefined) {
-    let optionProperty = optionName ? optionName : property;
+    const optionProperty = optionName ? optionName : property;
     options[optionProperty] = messageSettings[optionProperty];
     if (defaultSettings[property].datatype === 'number') {
       options[optionProperty] = parseInt(options[optionProperty]);
@@ -560,14 +560,14 @@ async function publishFeed(publisher:any, msg:any) {
   if (publisher.exited) {
     return;
   }
-  var {topic, payload} = generateEvent(msg.rule);
+  const {topic, payload} = generateEvent(msg.rule);
   publisher.publish(topic, payload, msg.options, msg.published++);
   publishStats[`${msg.message}-${msg.topic}`]++;
   Logger.success(`published ` +  
                 chalkEventCounterLabel(msg.message ? msg.message : 
                   msg.rule.eventName ? msg.rule.eventName : msg.ruleMessageName));
   if (msg.count > 0 && publishStats[`${msg.message}-${msg.topic}`] >= msg.count) {
-    var index = eventFeedTimers.findIndex((t) => t.name === msg.message && t.topic === msg.topic);
+    const index = eventFeedTimers.findIndex((t) => t.name === msg.message && t.topic === msg.topic);
     if (index < 0) {
       console.error('Hmm... could not find the timer');
       return;

--- a/src/lib/feed-validate.ts
+++ b/src/lib/feed-validate.ts
@@ -4,7 +4,7 @@ import { readAsyncAPIFile } from '../utils/config';
 import { chalkBoldError, chalkBoldWarning } from '../utils/chalkUtils';
 
 const validate = async (options: ManageFeedClientOptions, optionsSource: any) => {
-  var fileName = undefined;
+  let fileName = undefined;
 
   if (optionsSource.fileName === 'cli') fileName = options.fileName;
 

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -18,7 +18,7 @@ const publish = async (
 
   const { count, interval } = options;
   const publisher = new SolaceClient(options);
-  var interrupted = false;
+  let interrupted = false;
   try {
     await publisher.connect()
   } catch (error:any) {
@@ -42,10 +42,10 @@ const publish = async (
     }, options.exitAfter * 1000);
   }
 
-  var payloadType:any = options.payloadType as string;
-  var message:any = options.message as string;
+  let payloadType:any = options.payloadType as string;
+  let message:any = options.message as string;
 
-  var file:any = options.file as string;
+  const file:any = options.file as string;
   if (file) {
     if (!fileExists(file)) {
       Logger.logError(`missing file '${file}'`);
@@ -71,7 +71,7 @@ const publish = async (
 
   if (options.stdin) {
     Logger.ctrlDToPublish();
-    var readLines = new StdinRead();
+    const readLines = new StdinRead();
     await readLines.getData();
     message = readLines.data();
   }
@@ -103,7 +103,7 @@ const publish = async (
       }, 1500);
     }
   } else {
-    for (var iter=count ? count : 1, n=1;iter > 0;iter--, n++) {
+    for (let iter=count ? count : 1, n=1;iter > 0;iter--, n++) {
       if (options.queue) {
         for (var i=0; i<options.queue.length; i++) {
           if (optionsSource.file !== 'cli' && optionsSource.stdin !== 'cli' && optionsSource.message !== 'cli')

--- a/src/lib/receive.ts
+++ b/src/lib/receive.ts
@@ -14,7 +14,7 @@ const receive = async (
   }
 
   const receiver = new SolaceClient(options);
-  var interrupted = false;
+  let interrupted = false;
   try {
     await receiver.connect();
     receiver.subscribe(options);

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -17,7 +17,7 @@ const reply = async (
   }
 
   const replier = new SolaceClient(options);
-  var interrupted = false;
+  let interrupted = false;
 
   try {
     await replier.connect();
@@ -41,11 +41,11 @@ const reply = async (
     replier.exit();
   });
 
-  var payloadType:any = options.payloadType as string;
-  var message:any = options.message as string;
+  const payloadType:any = options.payloadType as string;
+  let message:any = options.message as string;
   message = (optionsSource.message !== 'cli' && (optionsSource.defaultMessage === 'default' || optionsSource.defaultMessage === 'cli')) ? getDefaultMessage() : message;
 
-  var file:any = options.file as string;
+  const file:any = options.file as string;
   if (file) {
     if (!fileExists(file)) {
       Logger.logError(`missing file '${file}'`);
@@ -65,7 +65,7 @@ const reply = async (
 
   if (options.stdin) {
     Logger.ctrlDToPublish();
-    var readLines = new StdinRead();
+    const readLines = new StdinRead();
     await readLines.getData();
     message = readLines.data();
   }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -18,7 +18,7 @@ const request = async (
 
   const { count, interval } = options;
   const requestor = new SolaceClient(options);
-  var interrupted = false;
+  let interrupted = false;
 
   try {
     await requestor.connect()
@@ -42,11 +42,11 @@ const request = async (
     requestor.exit();
   });
 
-  var payloadType:any = options.payloadType as string;
-  var message:any = options.message as string;
+  const payloadType:any = options.payloadType as string;
+  let message:any = options.message as string;
   message = (optionsSource.message !== 'cli' && (optionsSource.defaultMessage === 'default' || optionsSource.defaultMessage === 'cli')) ? getDefaultMessage() : message;
   
-  var file:any = options.file as string;
+  const file:any = options.file as string;
   if (file) {
     if (!fileExists(file)) {
       Logger.logError(`missing file '${file}'`);
@@ -66,7 +66,7 @@ const request = async (
 
   if (options.stdin) {
     Logger.ctrlDToPublish();
-    var readLines = new StdinRead();
+    const readLines = new StdinRead();
     await readLines.getData();
     message = readLines.data();
   }
@@ -74,11 +74,11 @@ const request = async (
   try {
     // if (options.replyToTopic)
     //   requestor.subscribe(options.replyToTopic)
-    var topicName = (typeof options.topic === 'object') ? options.topic[0] : options.topic;
+    const topicName = (typeof options.topic === 'object') ? options.topic[0] : options.topic;
     if (count === 1) {
       requestor.request(topicName, message, payloadType, 1);
     } else {
-      for (var iter=count ? count : 1, n=1;iter > 0;iter--, n++) {
+      for (let iter=count ? count : 1, n=1;iter > 0;iter--, n++) {
         requestor.request(topicName, message, payloadType, n);
         if (interval) await delay(interval)        
       }

--- a/src/lib/semp-connection.ts
+++ b/src/lib/semp-connection.ts
@@ -10,7 +10,7 @@ const sempConnection = (options: ManageClientOptions, optionsSource: any) => {
     process.exit(0);
   }
 
-  var count = 0;
+  let count = 0;
   Object.keys(optionsSource).forEach(key => count += optionsSource[key] === 'cli' ? 1 : 0)
   if (!count) {
     Logger.error('specify at least one or more parameters')

--- a/src/utils/chalkUtils.ts
+++ b/src/utils/chalkUtils.ts
@@ -57,7 +57,7 @@ export const chalkFeedAsyncAPIValue = (value: any) => {
 }
 
 export const colorizeTopic = (value: string, marker: string = '{') => {
-  let tokens = value.split('/');
+  const tokens = value.split('/');
   tokens.forEach((v, index) => {
     if (v.startsWith(marker)) 
       tokens[index] = chalkBoldVariable(v.toString())
@@ -78,7 +78,7 @@ export const wrapContent = (emptyPrefix: string, content:string, chunkSize:numbe
     return content;
 
   let result = chunks[0];
-  for (var i=1; i<chunks.length; i++) {
+  for (let i=1; i<chunks.length; i++) {
     result += '\n' + emptyPrefix + chunks[i];
   }
   

--- a/src/utils/checkparams.ts
+++ b/src/utils/checkparams.ts
@@ -210,7 +210,7 @@ export const checkSempQueuePartitionSettings = (options: ManageClientOptions) =>
 }
 
 export const checkSempQueueParamsExists = (options: ManageClientOptions, optionsSource: any) => {
-  var count = 0;
+  let count = 0;
   if (options.list) {
     count++; 
     options.operation = (typeof options.list === 'string') ? 'LIST_ITEM' : 'LIST';
@@ -260,7 +260,7 @@ export const checkSempQueueParamsExists = (options: ManageClientOptions, options
 }
 
 export const checkSempClientProfileParamsExists = (options: ManageClientOptions, optionsSource: any) => {
-  var count = 0;
+  let count = 0;
   if (options.list) {
     count++; 
     options.operation = (typeof options.list === 'string') ? 'LIST_ITEM' : 'LIST';
@@ -310,7 +310,7 @@ export const checkSempClientProfileParamsExists = (options: ManageClientOptions,
 }
 
 export const checkSempAclProfileParamsExists = (options: ManageClientOptions, optionsSource: any) => {
-  var count = 0;
+  let count = 0;
   if (options.list) {
     count++; 
     options.operation = (typeof options.list === 'string') ? 'LIST_ITEM' : 'LIST';
@@ -360,7 +360,7 @@ export const checkSempAclProfileParamsExists = (options: ManageClientOptions, op
 }
 
 export const checkSempClientUsernameParamsExists = (options: ManageClientOptions, optionsSource: any) => {
-  var count = 0;
+  let count = 0;
   if (options.list) {
     count++; 
     options.operation = (typeof options.list === 'string') ? 'LIST_ITEM' : 'LIST';
@@ -422,7 +422,7 @@ export const checkForFeedSettings = (eventNames:string[], feedName:string) => {
     process.exit(1)
   }
 
-  var data = loadLocalFeedFile(feedName, defaultFeedAnalysisFile);
+  const data = loadLocalFeedFile(feedName, defaultFeedAnalysisFile);
   if (!data.messages || !Object.keys(data.messages).length) {
     Logger.logError(`No event publish events found in the feed '${feedName}'`)
     Logger.logError('exiting...')
@@ -471,13 +471,13 @@ export const checkFeedRunOptions = (options: ManageFeedPublishOptions, optionsSo
 }
 
 export const getPotentialFeedName = (fileName: string) => {
-  var feedName = fileName.split('/').pop();
+  let feedName = fileName.split('/').pop();
   feedName = feedName?.split('.').shift() ?? '';// Add nullish coalescing operator to provide a default value
   return feedName;
 }
 
 export const getPotentialTopicFromFeedName = (name: string) => {
-  var feedName = name.replaceAll(' ', '').replaceAll('-', '/').toLowerCase();
+  const feedName = name.replaceAll(' ', '').replaceAll('-', '/').toLowerCase();
   return feedName;
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -130,7 +130,7 @@ export const compareConfiguration = (updated: any, current: any, commands: any) 
   keys.forEach((key) => {
     if (!commands.length || commands.includes(key)) {
       Logger.logInfo(`checking settings for operation - ${chalk.greenBright(key)}`)
-      let subKeys = Object.keys(updated.message[key]);
+      const subKeys = Object.keys(updated.message[key]);
       subKeys.forEach((subKey) => {
         if (!defaultMetaKeys.includes(subKey)) {
           if (current.message[key].hasOwnProperty(subKey) && updated.message[key].hasOwnProperty(subKey) && 
@@ -152,7 +152,7 @@ export const compareConfiguration = (updated: any, current: any, commands: any) 
   keys.forEach((key) => {
     if (!commands.length || commands.includes(key)) {
       Logger.logInfo(`checking settings for operation - ${chalk.greenBright(key)}`)
-      let subKeys = Object.keys(updated.manage[key]);
+      const subKeys = Object.keys(updated.manage[key]);
       subKeys.forEach((subKey) => {
         if (!defaultMetaKeys.includes(subKey)) {
           if (current.manage[key].hasOwnProperty(subKey) && updated.manage[key].hasOwnProperty(subKey) && 
@@ -235,14 +235,14 @@ export const saveConfig = (data: any) => {
     const configFile = data.config;
     delete data.config;
 
-    var updated = false;
+    let updated = false;
     const filePath = processPath(`${defaultStmHome}/${configFile}`)
       if (!filePath.endsWith('.json')) filePath.concat('.json')
     if (fileExists(filePath)) {
       const config:any = readFile(filePath)
       if (data.message.connection && compareConfiguration(data, config, []) > 0) {
-        var prompt = require('prompt-sync')();
-        var confirmation = prompt(`${chalk.whiteBright('Changes detected in the settings, do you want to overwrite (') + 
+        const prompt = require('prompt-sync')();
+        const confirmation = prompt(`${chalk.whiteBright('Changes detected in the settings, do you want to overwrite (') + 
                                     chalk.greenBright('y') + chalk.whiteBright('/') + 
                                     chalk.redBright('n') + chalk.whiteBright('): ')}`);
         if (!['Y', 'YES'].includes(confirmation.toUpperCase())) {
@@ -295,10 +295,10 @@ export const loadConfig = (configFile: string) => {
 export const createDefaultConfig = () => {
 
   // set the config to default config filename
-  var options:any = {}
+  const options:any = {}
   options.config = defaultConfigFile
 
-  var optionsSource:any = {};
+  const optionsSource:any = {};
   const defaultMessageKeys = Object.keys(defaultMessageConnectionConfig);
   for (var i=0; i<defaultMessageKeys.length; i++) {
     optionsSource[defaultMessageKeys[i]] = 'default'
@@ -315,7 +315,7 @@ export const createDefaultConfig = () => {
 
 export const loadCommandFromConfig = (cmd: string, options: MessageClientOptions | ManageClientOptions | ManageFeedPublishOptions) => {
   try {
-    var group = getCommandGroup(cmd)
+    const group = getCommandGroup(cmd)
     if (!options.config) {
       Logger.aid(`Hoho! No default configuration found, creating one for you...`)
       createDefaultConfig()
@@ -325,10 +325,10 @@ export const loadCommandFromConfig = (cmd: string, options: MessageClientOptions
       return readFile(defaultConfigFile)
     }
     
-    var commandName = options.name ? options.name : cmd
+    const commandName = options.name ? options.name : cmd
     const filePath = processPath(`${defaultStmHome}/${options.config as string}`)
     const localFilePath = processPath(`${options.config as string}`)
-    var config = null;
+    let config = null;
     if (fileExists(filePath)) {
       config = readFile(filePath)
       Logger.info(`loading '${commandName}' command from configuration '${chalk.cyanBright(filePath)}'`)
@@ -434,15 +434,15 @@ export const saveOrUpdateCommandSettings = (options: MessageClientOptions | Mana
   }
 
   try {
-    var newConfigCreated = false;
-    var group = getCommandGroup(options.command)
+    let newConfigCreated = false;
+    const group = getCommandGroup(options.command)
     if (!group) {
       Logger.logDetailedError(`unknown '${options.command}' command`, `specify a valid command name`)
       Logger.logError('exiting...')
       process.exit(1)
     }
 
-    var commandName = options.name ? options.name : options.command
+    let commandName = options.name ? options.name : options.command
     if (!commandName) {
       Logger.logDetailedError(`unknown '${commandName}' command name`, `missing or invalid valid command name`)
       Logger.logError('exiting...')
@@ -459,10 +459,10 @@ export const saveOrUpdateCommandSettings = (options: MessageClientOptions | Mana
     }
 
     // load current configuration
-    var current:any = loadConfig(options.config)
+    const current:any = loadConfig(options.config)
 
     // build configuration from the command line parameters
-    var updated = buildMessageConfig(current, options, optionsSource, [ group === 'manage' ? 'sempconnection' : 'connection', options.command]);
+    const updated = buildMessageConfig(current, options, optionsSource, [ group === 'manage' ? 'sempconnection' : 'connection', options.command]);
 
     // absorb unchanged params from the current -> updated
     Object.keys(optionsSource).forEach(key => {
@@ -487,7 +487,7 @@ export const saveOrUpdateCommandSettings = (options: MessageClientOptions | Mana
       }
     }
 
-    var newOrUpdate = (options.save && typeof options.save === 'string' && current[group][options.save] === undefined) ? 'new' : 'update'
+    const newOrUpdate = (options.save && typeof options.save === 'string' && current[group][options.save] === undefined) ? 'new' : 'update'
     if (newOrUpdate === 'new') {
       if (group === 'message') {
         current.message.connection = updated.message.connection;
@@ -521,10 +521,10 @@ export const saveOrUpdateCommandSettings = (options: MessageClientOptions | Mana
         }
 
         // compare and save
-        var count = compareConfiguration(updated, current, [ group === 'manage' ? 'sempconnection' : 'connection', commandName ]);
+        const count = compareConfiguration(updated, current, [ group === 'manage' ? 'sempconnection' : 'connection', commandName ]);
         if (count > 0) {
-          var prompt = require('prompt-sync')();
-          var confirmation = prompt(`${chalk.whiteBright('Changes detected in the settings, do you want to overwrite (') + 
+          const prompt = require('prompt-sync')();
+          const confirmation = prompt(`${chalk.whiteBright('Changes detected in the settings, do you want to overwrite (') + 
                                       chalk.greenBright('y') + chalk.whiteBright('/') + 
                                       chalk.redBright('n') + chalk.whiteBright('): ')}`);
           if (!['Y', 'YES'].includes(confirmation.toUpperCase())) {
@@ -581,8 +581,8 @@ export const createFeed = (fileName: string, feedName: string, feedJson: object,
         Logger.warn(`Feed '${feedName}' already exists, overwriting...`)
       } else {
         Logger.warn(`Feed '${feedName}' already exists, `)
-        var prompt = require('prompt-sync')();
-        var confirmation = prompt(`${chalk.whiteBright('Feed already exists, do you want to overwrite (') + 
+        const prompt = require('prompt-sync')();
+        const confirmation = prompt(`${chalk.whiteBright('Feed already exists, do you want to overwrite (') + 
                                     chalk.greenBright('y') + chalk.whiteBright('/') + 
                                     chalk.redBright('n') + chalk.whiteBright('): ')}`);
         if (!['Y', 'YES'].includes(confirmation.toUpperCase())) {
@@ -646,7 +646,7 @@ export const validateFeed = (feedName: string, type: string) => {
 export const loadLoadFeedInfo = (feedName: any) => {
   const feedPath = processPlainPath(`${defaultStmFeedsHome}/${feedName}`);
   try {
-    var info = readFile(`${feedPath}/${defaultFeedInfoFile}`);
+    const info = readFile(`${feedPath}/${defaultFeedInfoFile}`);
     return info;
   } catch (error: any) {
     Logger.logDetailedError('load feed info failed', error.toString())
@@ -661,7 +661,7 @@ export const updateAndLoadFeedInfo = (feed: any) => {
   try {
     writeJsonFile(`${feedPath}/${defaultFeedInfoFile}`, feed, true);
 
-    var info = readFile(`${feedPath}/${defaultFeedInfoFile}`);
+    const info = readFile(`${feedPath}/${defaultFeedInfoFile}`);
     return info;
   } catch (error: any) {
     Logger.logDetailedError('load feed info failed', error.toString())
@@ -678,7 +678,7 @@ export const loadLocalFeedSessionSettingsFile =(feedName: string, fileName: stri
       return false;
     }
 
-    var session = readFile(`${feedPath}/${fileName}`);
+    const session = readFile(`${feedPath}/${fileName}`);
     return session;
   } catch (error: any) {
     Logger.logDetailedError(`failed to fetch ${fileName}, check whether the feed exists!`, error.toString())
@@ -696,7 +696,7 @@ export const loadLocalFeedSessionFile = (feedName: string, fileName: string) => 
       throw new TypeError(`Feed session file not found!`);
     }
 
-    var analysis = readFile(`${feedPath}/${fileName}`);
+    const analysis = readFile(`${feedPath}/${fileName}`);
     return analysis;
   } catch (error: any) {
     throw new TypeError(`Feed session file not found!`);
@@ -712,7 +712,7 @@ export const loadLocalFeedFile = (feedName: string, fileName: string) => {
       process.exit(1);
     }
 
-    var analysis = readFile(`${feedPath}/${fileName}`);
+    const analysis = readFile(`${feedPath}/${fileName}`);
     return analysis;
   } catch (error: any) {
     Logger.logDetailedError(`failed to fetch ${fileName}, check whether the feed exists!`, error.toString())
@@ -731,7 +731,7 @@ export const loadRawLocalFeedFile = (feedName: string, fileName: string) => {
       process.exit(1);
     }
 
-    var analysis = readRawFile(`${feedPath}/${fileName}`);
+    const analysis = readRawFile(`${feedPath}/${fileName}`);
     return analysis;
   } catch (error: any) {
     Logger.logDetailedError(`failed to fetch ${fileName}, check whether the feed exists!`, error.toString())
@@ -752,7 +752,7 @@ export const loadLocalApiFeedRuleFile = (feedName: string, fileName: string) => 
     if (!fileExists(`${feedPath}/${fileName}`))
       return false;
 
-    var feedRules = readFile(`${feedPath}/${fileName}`);
+    const feedRules = readFile(`${feedPath}/${fileName}`);
     return feedRules;
   } catch (error: any) {
     Logger.logDetailedError(`failed to fetch ${fileName}, check whether the feed exists!`, error.toString())
@@ -768,7 +768,7 @@ export const getAllFeeds = () => {
   const feeds: any[] = [];
   
   directories.forEach((feedName: string) => {
-    var stat = fs.lstatSync(`${feedPath}/${feedName}`);
+    const stat = fs.lstatSync(`${feedPath}/${feedName}`);
     if (stat.isDirectory() && fs.existsSync(`${feedPath}/${feedName}/${defaultFeedInfoFile}`)) {
       const info:any = loadLocalFeedFile(feedName, defaultFeedInfoFile) ;
       feeds.push({
@@ -793,10 +793,10 @@ export const getFeed = (feedName: string, info: any = null) => {
   if (!info) info = loadLocalFeedFile(feedName, defaultFeedInfoFile) ;
 
   files.forEach((fileName: string) => {
-    var filePath = `${configPath}/${fileName}`
-    var stat = fs.lstatSync(filePath);
+    const filePath = `${configPath}/${fileName}`
+    const stat = fs.lstatSync(filePath);
     if (!stat.isDirectory() && fileName.endsWith('.json')) {
-      var broker = readFile(`${configPath}/${fileName}`);
+      const broker = readFile(`${configPath}/${fileName}`);
       if (broker?.message?.connection)
         brokers.push({broker: fileName, config: broker?.message?.connection});
     }
@@ -846,7 +846,7 @@ export const updateSession = async (feedName: string, sessionJson: any) => {
 
     writeFile(`${sessionFile}`, sessionJson)
 
-    var info = loadLocalFeedFile(feedName, defaultFeedInfoFile);
+    const info = loadLocalFeedFile(feedName, defaultFeedInfoFile);
     info.lastUpdated = new Date().toISOString();
     writeJsonFile(`${feedPath}/${defaultFeedInfoFile}`, info, true);
     return true;
@@ -868,7 +868,7 @@ export const updateRules = async (feedName: string, rulesJson: any) => {
 
     writeFile(`${rulesFile}`, rulesJson)
 
-    var info = loadLocalFeedFile(feedName, defaultFeedInfoFile);
+    const info = loadLocalFeedFile(feedName, defaultFeedInfoFile);
     info.lastUpdated = new Date().toISOString();
     writeJsonFile(`${feedPath}/${defaultFeedInfoFile}`, info, true);
     return true;
@@ -890,7 +890,7 @@ export const updateApiRules = async (feedName: string, rulesJson: any) => {
 
     writeFile(`${rulesFile}`, rulesJson)
 
-    var info = loadLocalFeedFile(feedName, defaultFeedInfoFile);
+    const info = loadLocalFeedFile(feedName, defaultFeedInfoFile);
     info.lastUpdated = new Date().toISOString();
     writeJsonFile(`${feedPath}/${defaultFeedInfoFile}`, info, true);
     return true;
@@ -933,7 +933,7 @@ export const urlExists = async (url:any) => {
 
 export const validURL = (url:any) => {
 	try {
-		return new URL(url.trim()) // eslint-disable-line no-new
+		return new URL(url.trim())  
 	} catch (_e) {
 		return null
 	}
@@ -941,8 +941,8 @@ export const validURL = (url:any) => {
 
 export const loadGitFeedSessionFile = async (feedName: string, fileName: string) => {
   try {
-    var feedUrl = `${defaultGitRepo}/${feedName}`;
-    var validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
+    const feedUrl = `${defaultGitRepo}/${feedName}`;
+    const validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
     if (!validFeedUrl) {
       throw new TypeError(`Feed session file not found!`);
     }
@@ -962,8 +962,8 @@ export const loadGitFeedSessionFile = async (feedName: string, fileName: string)
 
 export const loadGitFeedFile = async (feedName: string, fileName: string) => {
   try {
-    var feedUrl = `${defaultGitRepo}/${feedName}`;
-    var validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
+    const feedUrl = `${defaultGitRepo}/${feedName}`;
+    const validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
     if (!validFeedUrl) {
       Logger.logDetailedError('invalid or non-existing feed URL', feedUrl)
       Logger.logError('exiting...')
@@ -990,8 +990,8 @@ export const loadGitFeedFile = async (feedName: string, fileName: string) => {
 
 export const loadRawGitFeedFile = async (feedName: string, fileName: string) => {
   try {
-    var feedUrl = `${defaultGitRepo}/${feedName}`;
-    var validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
+    const feedUrl = `${defaultGitRepo}/${feedName}`;
+    const validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
     if (!validFeedUrl) {
       Logger.logDetailedError('invalid or non-existing feed URL', feedUrl)
       Logger.logError('exiting...')
@@ -1017,8 +1017,8 @@ export const loadRawGitFeedFile = async (feedName: string, fileName: string) => 
 
 export const loadGitApiFeedRuleFile = async (feedName: string, fileName: string) => {
   try {
-    var feedUrl = `${defaultGitRepo}/${feedName}`;
-    var validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
+    const feedUrl = `${defaultGitRepo}/${feedName}`;
+    const validFeedUrl = await urlExists(encodeURI(`${feedUrl}/${fileName}`));
     if (!validFeedUrl) {
       Logger.logDetailedError('invalid or non-existing feed URL', feedUrl)
       Logger.logError('exiting...')
@@ -1047,8 +1047,8 @@ export const createApiFeed = (feed: any) => {
   try {
     if (fileExists(feedPath)) {
       Logger.warn(`Feed '${feed.name}' already exists, `)
-      var prompt = require('prompt-sync')();
-      var confirmation = prompt(`${chalk.whiteBright('Feed already exists, do you want to overwrite (') + 
+      const prompt = require('prompt-sync')();
+      const confirmation = prompt(`${chalk.whiteBright('Feed already exists, do you want to overwrite (') + 
                                   chalk.greenBright('y') + chalk.whiteBright('/') + 
                                   chalk.redBright('n') + chalk.whiteBright('): ')}`);
       if (!['Y', 'YES'].includes(confirmation.toUpperCase())) {

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -423,8 +423,8 @@ export const getType = (message:solace.Message) => {
   }
 }
 
-var currentHomeDir = require('os').homedir();
-var currentStmHome = `${currentHomeDir}/.stm`;
+const currentHomeDir = require('os').homedir();
+let currentStmHome = `${currentHomeDir}/.stm`;
 
 if (process.env.STM_HOME) {
   currentStmHome = process.env.STM_HOME;

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -44,8 +44,8 @@ export const initializeConfig = (options:StmConfigOptions, optionsSource: any) =
   const filePath = processPath(`${defaultStmHome}/${configFile}`)
   if (!filePath.endsWith('.json')) filePath.concat('.json')
   if (fileExists(filePath)) {
-    var prompt = require('prompt-sync')();
-    var confirmation = prompt(`${chalk.whiteBright(`Config file '${decoratePath(configFile)}' exists , do you want to reinitialize (`) + 
+    const prompt = require('prompt-sync')();
+    const confirmation = prompt(`${chalk.whiteBright(`Config file '${decoratePath(configFile)}' exists , do you want to reinitialize (`) + 
                                 chalk.greenBright('y') + chalk.whiteBright('/') + 
                                 chalk.redBright('n') + chalk.whiteBright('): ')}`);
     if (!['Y', 'YES'].includes(confirmation.toUpperCase())) {
@@ -81,7 +81,7 @@ export const deleteConfig = (options:StmConfigOptions, optionsSource: any) => {
   }
 
   // load current configuration
-  var current:any = loadConfig(options.config)
+  const current:any = loadConfig(options.config)
   current.config = options.config
 
   if (options.name) {
@@ -97,8 +97,8 @@ export const deleteConfig = (options:StmConfigOptions, optionsSource: any) => {
       process.exit(1)
     }
 
-    var prompt = require('prompt-sync')();
-    var confirmation = prompt(`${chalk.whiteBright(`Are you sure you want to delete the command '${options.name}' on configuration '${options.config}' (`) + 
+    const prompt = require('prompt-sync')();
+    const confirmation = prompt(`${chalk.whiteBright(`Are you sure you want to delete the command '${options.name}' on configuration '${options.config}' (`) + 
                                 chalk.greenBright('y') + chalk.whiteBright('/') + 
                                 chalk.redBright('n') + chalk.whiteBright('): ')}`);
     if (!['Y', 'YES'].includes(confirmation.toUpperCase())) {
@@ -116,7 +116,7 @@ export const deleteConfig = (options:StmConfigOptions, optionsSource: any) => {
 
 export const listConfig = (options:StmConfigOptions, optionsSource: any) => {
   const { helpExamples } = options
-  var AsciiTable = require('ascii-table')
+  const AsciiTable = require('ascii-table')
 
   if (helpExamples) {
     displayHelpExamplesForConfigList()
@@ -130,7 +130,7 @@ export const listConfig = (options:StmConfigOptions, optionsSource: any) => {
   }
 
 
-  var count = 0;
+  let count = 0;
   var table = new AsciiTable('Connection Settings')
   table.setHeading('Command', 'Name', 'Broker URL', 'Message VPN', 'Username', 'Password' )
   count++
@@ -167,7 +167,7 @@ export const listConfig = (options:StmConfigOptions, optionsSource: any) => {
         table.addRow((selected.command.toUpperCase() !== lastOp ? selected.command.toUpperCase() : ''), 
                       selected.name, '[ ', config.connection.url,
                       config.connection.vpn, config.connection.username + '/' + "******")
-        for (var i=0; i<selected.topic.length; i++) {
+        for (let i=0; i<selected.topic.length; i++) {
           table.addRow('', '', '  "' + selected.topic[i] + (i === selected.topic.length-1 ? '"' : '",'), '', '', '');
         }
         table.addRow('', '', ']', '', '', '');
@@ -211,7 +211,7 @@ export const buildConfig = (options:any, optionsSource: any, commandType: Comman
   const configFile = optionsSource.config === 'cli' && typeof options.config === 'string' ? options.config : defaultConfigFile;
   Logger.logDetailedSuccess(`loading ${configFile === defaultConfigFile ? 'from default' : 'from'} configuration file`, `${decoratePath(configFile)}`)
   const config = loadConfig(configFile);
-  var commands:string[] = [];
+  let commands:string[] = [];
   commands = commands.concat(Object.keys(config.manage))
   commands = commands.concat(Object.keys(config.message))
 
@@ -396,7 +396,7 @@ export const buildMessageConfig = (current: any, options:any, optionsSource: any
 
   // fix up name
   if (optionsSource.name === 'cli') {
-    let group = getCommandGroup(options.command)
+    const group = getCommandGroup(options.command)
     if (!group) {
       Logger.logDetailedError('unknown command  - ', options.command)
       Logger.logError('exiting...')

--- a/src/utils/listfeeds.ts
+++ b/src/utils/listfeeds.ts
@@ -3,15 +3,15 @@ import { loadLocalFeedFile, loadGitFeedFile, processPlainPath } from './config';
 import { defaultEventFeedsFile, defaultFeedAnalysisFile, defaultFeedInfoFile, defaultGitFeedRepo, defaultGitRepo, defaultStmFeedsHome } from './defaults';
 
 export const getLocalEventFeeds = () => {
-  var localFeeds: any[] = [];
+  const localFeeds: any[] = [];
   const feedPath = processPlainPath(`${defaultStmFeedsHome}`);
   if (!fs.existsSync(`${feedPath}`)) 
     return localFeeds;
   
   const files:any = fs.readdirSync(`${feedPath}`);
   files.forEach((fileName: string) => {
-    var filePath = `${feedPath}/${fileName}`
-    var stat = fs.lstatSync(filePath);
+    const filePath = `${feedPath}/${fileName}`
+    const stat = fs.lstatSync(filePath);
     if (stat.isDirectory() && fs.existsSync(`${filePath}/${defaultFeedInfoFile}`)) {
       localFeeds.push(fileName)
     }
@@ -21,10 +21,10 @@ export const getLocalEventFeeds = () => {
 }
 
 export const getFeedEvents = (feedName:any) => {
-  var events: any[] = [];
-  var data = loadLocalFeedFile(feedName, defaultFeedAnalysisFile)
+  const events: any[] = [];
+  const data = loadLocalFeedFile(feedName, defaultFeedAnalysisFile)
   Object.keys(data.messages).forEach((messageName) => {
-    var sendEvents = data.messages[messageName].send;
+    const sendEvents = data.messages[messageName].send;
     if (sendEvents.length) {
       sendEvents.forEach((_event:any) => {
         events.push({
@@ -39,7 +39,7 @@ export const getFeedEvents = (feedName:any) => {
 }
 
 export const getGitEventFeeds = async () => {
-  var gitFeeds: any[] = [];
+  const gitFeeds: any[] = [];
   try {
     await fetch(`${defaultGitRepo}/${defaultEventFeedsFile}`)
       .then(async (response) => {
@@ -54,10 +54,10 @@ export const getGitEventFeeds = async () => {
 }
 
 export const getGitFeedEvents = async (feedName:any) => {
-  var events: any[] = [];
-  var data = await loadGitFeedFile(feedName, defaultFeedAnalysisFile)
+  const events: any[] = [];
+  const data = await loadGitFeedFile(feedName, defaultFeedAnalysisFile)
   Object.keys(data.messages).forEach((messageName) => {
-    var sendEvents = data.messages[messageName].send;
+    const sendEvents = data.messages[messageName].send;
     if (sendEvents.length) {
       sendEvents.forEach((_event:any) => {
         events.push({

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -88,8 +88,8 @@ const Logger = {
   await: (message: string) => Signal.await(chalk.cyanBright(message)),
   alert: (message: string) => Signal.alert(chalk.bgMagenta(message)),
   dumpMap: (map: any) => {
-    var keys = map.getKeys();
-    var str = '';
+    const keys = map.getKeys();
+    let str = '';
     keys.forEach((key: any, idx: number) => {
       str += `${key.padEnd(24, ' ')} ${map.getField(key).getValue()}`;
       if (idx < keys.length-1) str += `\r\n`;
@@ -121,13 +121,13 @@ const Logger = {
   },
   
   prettyPrintMessage: (message: any, payload:any, messageType: number, outputMode:string, pretty: boolean) => {
-    var properties = message.dump(0);
+    let properties = message.dump(0);
     if (messageType === 1) { // MAP MESSAGE
-      var map = message.getSdtContainer();
-      var keys = map.getKeys();
+      const map = message.getSdtContainer();
+      const keys = map.getKeys();
       properties = '';
       keys.forEach((key: any, idx: number) => {
-        var field = map.getField(key);
+        const field = map.getField(key);
         if (field.getType() === 15)
           properties += `${key.padEnd(24, ' ')} ${Logger.printStream(field.getValue(), '')}`;
         else
@@ -136,13 +136,13 @@ const Logger = {
       });
     }
 
-    var userProperties = message.getUserPropertyMap();
+    const userProperties = message.getUserPropertyMap();
 
     if (outputMode?.toUpperCase() === 'FULL') {
       properties = properties.replace(/User Property Map:.*entries\n/, '')
       let userProps = '';
       if  (userProperties) {
-        let keys = userProperties.getKeys();
+        const keys = userProperties.getKeys();
         keys.forEach((key: any, idx: number) => {
           userProps += padString(4, `${key}:`, 40) + userProperties.getField(key).getValue();          
           if (idx < keys.length-1) userProps += `\r\n`;
@@ -186,7 +186,7 @@ const Logger = {
     } else if (outputMode?.toUpperCase() === 'PROPS') {
       properties = properties.replace(/User Property Map:.*entries\n/, '')
       let userProps = '';
-      let keys = userProperties.getKeys();
+      const keys = userProperties.getKeys();
       keys.forEach((key: any, idx: number) => {
         userProps += padString(4, `${key}:`, 40) + userProperties.getField(key).getValue();          
         if (idx < keys.length-1) userProps += `\r\n`;
@@ -233,8 +233,8 @@ const Logger = {
   },
 
   dumpMessage: (message: any, outputMode: string, pretty: boolean) => {
-    var payload = undefined;
-    var messageType = message.getType();
+    let payload = undefined;
+    const messageType = message.getType();
     if (messageType === 0) { // binary
       payload = message.getBinaryAttachment();
       if (!payload)

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -193,7 +193,7 @@ export const parsePartitionKeysCount = (value: string) => {
 }
 
 export const parseMessageProtocol = (value: string) => {
-  var protocol = value.substring(0, value.indexOf( ":" )); 
+  const protocol = value.substring(0, value.indexOf( ":" )); 
   if (!['ws', 'wss', 'http', 'https', 'tcp', 'tcps'].includes(protocol.toLowerCase())) {
     Logger.logError('only ws, wss, http, https, tcp, and tcps are supported.')
     Logger.logError('exiting...')
@@ -203,7 +203,7 @@ export const parseMessageProtocol = (value: string) => {
 }
 
 export const parseManageProtocol = (value: string) => {
-  var protocol = value.substring(0, value.indexOf( ":" )); 
+  const protocol = value.substring(0, value.indexOf( ":" )); 
   if (!['http', 'https'].includes(protocol.toLowerCase())) {
     Logger.logError('only http and https are supported.')
     Logger.logError('exiting...')
@@ -312,8 +312,8 @@ export const parsePartitionKeysList = (value: string, previous: string[] | undef
 export const parseUserProperties = (value: string, previous?: Record<string, string | string[]>) => {
   const [key, val] = value.split(':')
   if (key && val) {
-    var _key = key.trim();
-    var _val = val.trim();
+    const _key = key.trim();
+    const _val = val.trim();
     if (!previous) {
       return { [_key]: _val }
     } else {

--- a/src/utils/prettify.ts
+++ b/src/utils/prettify.ts
@@ -3,30 +3,30 @@
 import { prettyPrint } from '@base2/pretty-print-object';
 import { Logger } from './logger';
 import chalk from 'chalk';
-var _os = require('os');
+const _os = require('os');
 
-var stringTimesN = function stringTimesN(n:number, char:string) {
+const stringTimesN = function stringTimesN(n:number, char:string) {
   return Array(n + 1).join(char);
 };
 
 // Adapted from https://gist.github.com/sente/1083506
 function prettifyXml(xmlInput:string, options: any) {
-  var _options$indent = options.indent,
+  const _options$indent = options.indent,
       indentOption = _options$indent === undefined ? 2 : _options$indent,
       _options$newline = options.newline,
       newlineOption = _options$newline === undefined ? _os.EOL : _options$newline;
 
-  var indentString = stringTimesN(indentOption, ' ');
+  const indentString = stringTimesN(indentOption, ' ');
 
-  var formatted = '';
-  var regex = /(>)\s*(<)(\/*)/g;
-  var xml = xmlInput.replace(regex, '$1' + newlineOption + '$2$3');
+  let formatted = '';
+  const regex = /(>)\s*(<)(\/*)/g;
+  const xml = xmlInput.replace(regex, '$1' + newlineOption + '$2$3');
 
-  var pad = 0;
+  let pad = 0;
   xml.split(/\r?\n/).forEach(function (l:any) {
-    var line = l.trim();
+    const line = l.trim();
 
-    var indent = 0;
+    let indent = 0;
     if (line.match(/.+<\/\w[^>]*>$/)) {
       indent = 0;
     } else if (line.match(/^<\/\w/)) {
@@ -41,8 +41,8 @@ function prettifyXml(xmlInput:string, options: any) {
       indent = 0;
     }
 
-    var padding = stringTimesN(pad, indentString);
-    formatted += padding + line + newlineOption; // eslint-disable-line prefer-template
+    const padding = stringTimesN(pad, indentString);
+    formatted += padding + line + newlineOption;  
     pad += indent;
   });
 
@@ -52,7 +52,7 @@ function prettifyXml(xmlInput:string, options: any) {
 function prettyXML(str: string, indent: number) {
   if (!str) return str;
   if (str.trim().startsWith('<')) {
-    var result = prettifyXml(str, {indent: indent, newline: '\n'});
+    const result = prettifyXml(str, {indent: indent, newline: '\n'});
     return result;
   } else {
     // Logger.warn(`not a valid xml payload`)
@@ -63,15 +63,15 @@ function prettyXML(str: string, indent: number) {
 function prettyJSON(str: string) {
   if (!str) return str;
   try {
-    let isNum = /^\d+$/.test(str);
+    const isNum = /^\d+$/.test(str);
 
-      var obj = isNum ? str : JSON.parse(str);
+      const obj = isNum ? str : JSON.parse(str);
       // var output = chalk.green(JSON.stringify(obj, null, 2));
       // return prettyPrint(obj, {
       //   indent: '  ',
       //   singleQuotes: false
       // });
-      var output = colorizeJSON(obj, 2);
+      const output = colorizeJSON(obj, 2);
       return output
   } catch (error: any) {
     // Logger.warn(`not a valid json payload`)

--- a/src/utils/shorthash.ts
+++ b/src/utils/shorthash.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-const */
-/* eslint-disable no-param-reassign */
-/* eslint-disable no-bitwise */
-/* eslint-disable no-plusplus */
+ 
+ 
+ 
 /**
  * shorthash2 Jecsham (c) 2020
  * Based in shorthash (c) 2013 Bibig https://github.com/bibig/node-shorthash (MIT)

--- a/src/utils/visualize.ts
+++ b/src/utils/visualize.ts
@@ -11,7 +11,7 @@ const visualize = async (options: MessageClientOptions) => {
   const url = new URL(config.url);
   console.log(config.url, '\n', url);
   console.log(url.hostname, config.url.substring(config.url.lastIndexOf(':')+1), config.username, "******");
-  var publicDir = __dirname.substring(0, __dirname.lastIndexOf('solace-tryme-cli') + 16);
+  const publicDir = __dirname.substring(0, __dirname.lastIndexOf('solace-tryme-cli') + 16);
 
   const express = require('express');
   const app = express();
@@ -21,7 +21,7 @@ const visualize = async (options: MessageClientOptions) => {
   });
   
   app.get('/config', (req:any, res:any) => {
-    var configuration = {
+    const configuration = {
       "MQTT_HOST": `${url.hostname}`,
       "MQTT_PORT": (url.hostname === 'localhost' ? 8000: 8443),
       "MQTT_USER_NAME":   `${config.username}`,
@@ -36,11 +36,11 @@ const visualize = async (options: MessageClientOptions) => {
     res.send("Success");
   })
 
-  let http = require('http');
-  let server = http.createServer(app);
+  const http = require('http');
+  const server = http.createServer(app);
   server.listen(visualizationPort, () => {
     console.info(`App listening on port ${server.address().port}`);
-    var opener = require("opener");
+    const opener = require("opener");
     opener(`http://localhost:${server.address().port}`)
   });
 


### PR DESCRIPTION
- Updated variable declarations from var to let or const in feed-validate.ts, publish.ts, receive.ts, reply.ts, request.ts, semp-connection.ts, chalkUtils.ts, checkparams.ts, config.ts, defaults.ts, init.ts, listfeeds.ts, logger.ts, parse.ts, prettify.ts, shorthash.ts, visualize.ts.
- This change improves code readability and maintains block scope for variables.