### PR TITLE
Fix connect() promise hangs and improve command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Solace Try-Me CLI 
 
-The Solace Try-Me CLI (_**stm**_) is a command-line tool designed for messaging and streaming operations. It simplifies tasks like publishing, receiving, and performing request-reply messaging with a Solace PubSub+ Broker — all directly from the command line and without requiring any coding.
+The Solace Try-Me CLI (_**stm**_) is a command-line tool designed for messaging and streaming operations. It simplifies tasks like publishing, receiving, and performing request-reply messaging with a Solace PubSub+ Broker, all directly from the command line and without requiring any coding.
 
 ![](docrefs/messaging.webp "stm - messaging")
 
-_**stm**_ provides a feature to generate event feeds directly from AsyncAPI documents representing asynchronous applications or APIs (command _**feed**_). These feeds enable seamless streaming of events as specified in the document—entirely code-free. The streamed events include mock payload data, generated using the Faker.js library, ensuring conformity to the data types and formats defined in the document. Additionally, STM's feed functionality allows users to define custom data-generation rules from an extensive library of rule sets, producing realistic values for payload fields across categories such as strings, numbers, personal data, locations, internet, finance, and more.
+_**stm**_ provides a feature to generate event feeds directly from AsyncAPI documents representing asynchronous applications or APIs (command _**feed**_). These feeds enable seamless streaming of events as specified in the document, entirely code-free. The streamed events include mock payload data, generated using the Faker.js library, ensuring conformity to the data types and formats defined in the document. Additionally, STM's feed functionality allows users to define custom data-generation rules from an extensive library of rule sets, producing realistic values for payload fields across categories such as strings, numbers, personal data, locations, internet, finance, and more.
 
 > **Continue reading this [document](./README.md) to know more about how to use `stm` CLI for messaging.**
 
@@ -42,8 +42,9 @@ The Solace Try-Me CLI is a command line tool used to publish and receive message
     - [Use with a Cloud Broker](#use-with-a-cloud-broker)
   - [Run `stm` tool](#run-stm-tool)
     - [Working with Software Broker](#working-with-software-broker)
-    - [Receive Messages](#receive-messages)
-    - [Browse a Queue](#browse-a-queue)
+      - [Send and Receive Messages](#send-and-receive-messages)
+      - [Request and Reply](#request-and-reply)
+      - [Browse a Queue](#browse-a-queue)
     - [Working with Cloud Broker](#working-with-cloud-broker)
   - [Using `stm` to create and modify Broker resources](#using-stm-to-create-and-modify-broker-resources)
     - [Create a Queue](#create-a-queue)
@@ -304,9 +305,12 @@ Changes detected in the settings, do you want to overwrite (y/n): y
 
 ### Working with Software Broker
 
-Once you complete the `stm` setup process and a configuration is successfully created, you can run the messaging commands.
+Once you complete the `stm` setup process and a configuration is successfully created, you can run the messaging commands. The default configuration already points at the local software broker, so the commands below work out of the box.
 
-### Receive Messages
+#### Send and Receive Messages
+
+This walks through the publish/subscribe pattern. Start the receiver first so it is subscribed before you publish.
+
 ``` code
 stm receive
 ℹ  info: loading configuration 'stm-cli-config.json'
@@ -336,7 +340,7 @@ Destination:                            [Topic solace/try/me]
 
 At this point, you should see the event received on the receiver.
 
-```code
+``` code
 ✔  success: message Received - [Topic solace/try/me], type - BINARY
 ℹ  info: Message Properties
 Destination:                            [Topic solace/try/me]
@@ -345,9 +349,53 @@ Destination:                            [Topic solace/try/me]
 
 **NOTE:** `stm` supports a default output mode that prints the destination and the message payload length (not the payload itself). However, if you want more details around message & user properties and payload - explore the other options i.e., `PROPS` to print message properties + just payload length, and `FULL` to print message properties and a pretty-print of the payload.
 
-### Browse a Queue
+#### Request and Reply
+
+This walks through the request/reply pattern. Start the replier first so it is subscribed to the request topic (default `solace/try/me/request`) before you send a request.
+
+``` code
+stm reply
+ℹ  info: loading 'reply' command from configuration 'stm-cli-config.json'
+…  connecting to broker [ws://localhost:8008, vpn: default, username: default, password: ******]
+✔  success: === stm_rep_7c1a2b3d successfully connected and ready to subscribe to request topic. ===
+ℹ  info: subscribing to solace/try/me/request
+✔  success: successfully subscribed to request topic: solace/try/me/request
+…  === ready to receive requests. ===
+```
+
+On a second window/terminal, send a request. The replier responds automatically and the requestor prints the reply it receives.
+
+``` code
+stm request
+ℹ  info: loading 'request' command from configuration 'stm-cli-config.json'
+…  connecting to broker [ws://localhost:8008, vpn: default, username: default, password: ******]
+✔  success: === stm_req_9f3e1c07 successfully connected and ready to send requests. ===
+…  requesting...
+✔  success: request sent on topic solace/try/me/request, type - TEXT
+✔  success: reply received, type - TEXT
+```
+
+Back on the replier window, you will see the matching request handled:
+
+``` code
+✔  success: request received - [Topic solace/try/me/request], type - TEXT
+…  replying to request on topic 'solace/try/me/request', type - TEXT
+✔  success: reply sent
+✔  success: replied.
+```
+
+The replier keeps running and answers each request until you stop it with Ctrl-C.
+
+#### Browse a Queue
 
 The `browse` command inspects the messages spooled on a queue without consuming them. Browsing is non-destructive - the messages are read from oldest to newest and remain on the queue, available for normal consumption.
+
+**Prerequisite:** `browse` only shows messages already spooled on the queue, so the queue must exist and contain messages. You can create it and publish a few messages directly to it first (see [Create a Queue](#create-a-queue)):
+
+``` code
+stm manage queue --create my-queue
+stm send --queue my-queue --count 3
+```
 
 ``` code
 stm browse --queue my-queue
@@ -364,13 +412,31 @@ hello-browse
 
 **NOTE:** `browse` binds to an existing queue only, so unlike `receive` it does not accept topic subscriptions or the `--create-if-missing` option. Use `--output-mode FULL` to inspect message and user properties along with a pretty-printed payload.
 
+**What is and is not supported**
+
+`browse` is a thin wrapper over the Solace `QueueBrowser`, so it inherits that API's capabilities and limits:
+
+**Supported**
+- Non-destructive read of a durable **Queue** endpoint - messages stay spooled and remain available for normal consumption.
+- Browsing always starts from the **head of the queue** and proceeds oldest to newest. This is the default and only ordering.
+- `--window-size` to tune how many messages the broker prefetches to the browser (valid range 1-255, default 50). This only affects prefetch, not where browsing starts.
+- `--output-mode DEFAULT | PROPS | FULL` to control how much of each message is printed.
+
+**Not supported**
+- **No starting position, offset, or message selector.** You cannot browse from the tail, from a specific message id, or by a selector expression - browsing always begins at the head. (Position-based replay is a `receive`/consumer feature, not a browser one.)
+- **No message removal or acknowledgement.** Browsing never deletes or acks messages. To consume messages use `receive`; to remove them use `stm manage queue`.
+- **Queue endpoints only.** Topic endpoints are not supported for browsing.
+- **No topic subscriptions and no `--create-if-missing`.** `browse` binds to an existing queue only.
+
+Because browsing is stateless, each new `browse` session re-binds and starts again at the current head (the oldest message still spooled at that moment); there is no persisted cursor.
+
 ### Working with Cloud Broker
 
 Since the connection parameters are distinct for Cloud Broker, you will have to create a new Try-Me CLI configuration with appropriate connection parameters. You can make the `stm` operations directed to a specific broker by specifying the configuration that holds that broker's connection details by specifying `--config <CONFIG_FILE>` parameter.
 
 At this point, the functionality of messaging commands are same irrespective of local or cloud broker. Try `stm send` and `stm receive` commands with a configuration containing cloud broker.
 
-🎉 You are set, explore other commands like `request`, `reply` and the parameters that goes along with the messaging commands!
+🎉 You are set! Explore the `feed` command and the full set of parameters that go along with each messaging command.
 
 ## Using `stm` to create and modify Broker resources
 

--- a/documentation/MESSAGING_PARAMETERS.md
+++ b/documentation/MESSAGING_PARAMETERS.md
@@ -164,7 +164,7 @@ Options:
 The `receive` command consumes messages by subscribing to one or more topics and/or binding to a queue endpoint. Unlike `browse`, consumption from a queue is destructive: received messages are acknowledged and removed.
 
 - **Supported:** topic subscriptions (`-t`, including wildcards `>` and `*`) and/or a queue binding (`-q`); creating the queue on the fly with `--create-if-missing`; `AUTO` or `CLIENT` acknowledgement (`--acknowledge-mode`).
-- **Not supported:** it is not non-destructive - to inspect messages without removing them use `browse` instead.
+- **Not supported:** consumption from a queue is destructive; to inspect messages without removing them use `browse` instead.
 
 <details>
 <summary>Basic Parameters: <i><b>stm receive -h</b></i> </summary>

--- a/documentation/MESSAGING_PARAMETERS.md
+++ b/documentation/MESSAGING_PARAMETERS.md
@@ -49,6 +49,11 @@ __Issue messaging commands: publish, receive, browse, request and reply__
 
 ## Publish Events
 
+The `send` command publishes one or more messages to one or more topics and/or queues. The payload can be supplied inline (`-m`), from a file (`-f`), from stdin (`--stdin`), or as a default/empty body, and can be sent repeatedly with `--count` and `--interval`.
+
+- **Supported:** publishing to topics (`-t`) and/or queues (`-q`); `DIRECT` or `PERSISTENT` delivery (`--delivery-mode`); guaranteed publishing with confirmations (`--publish-confirmation`, `--window-size`, `--acknowledge-mode`); partition keys; per-message TTL and DMQ eligibility, application message id/type, user properties, and HTTP content-type/encoding; `TEXT` or `BYTES` payloads.
+- **Not supported:** it does not wait for a reply (use `request` for request-reply) and does not consume or browse messages.
+
 <details>
 <summary>Basic Parameters: <i><b>stm send -h</b></i> </summary>
 
@@ -155,6 +160,12 @@ Options:
 </details>
 
 ## Receive Events
+
+The `receive` command consumes messages by subscribing to one or more topics and/or binding to a queue endpoint. Unlike `browse`, consumption from a queue is destructive: received messages are acknowledged and removed.
+
+- **Supported:** topic subscriptions (`-t`, including wildcards `>` and `*`) and/or a queue binding (`-q`); creating the queue on the fly with `--create-if-missing`; `AUTO` or `CLIENT` acknowledgement (`--acknowledge-mode`).
+- **Not supported:** it is not non-destructive - to inspect messages without removing them use `browse` instead.
+
 <details>
 <summary>Basic Parameters: <i><b>stm receive -h</b></i> </summary>
 
@@ -232,6 +243,13 @@ Options:
 
 The `browse` command inspects the messages spooled on a queue without consuming them. Browsing is non-destructive - messages are read from oldest to newest and remain on the queue, available for normal consumption. Unlike `receive`, `browse` binds to an existing queue only, so it does not accept topic subscriptions or the `--create-if-missing` option.
 
+`browse` wraps the Solace `QueueBrowser`, so it inherits that API's capabilities and limits:
+
+- **Supported:** non-destructive read of a durable **Queue** endpoint; browsing always starts from the **head** and proceeds oldest to newest (the default and only ordering); `--window-size` to tune broker prefetch (1-255, default 50, affects prefetch only, not starting point); `--output-mode DEFAULT | PROPS | FULL` for print detail.
+- **Not supported:** no starting position, offset, or message selector (you cannot browse from the tail, a specific message id, or by selector - it always begins at the head); no message removal or acknowledgement (use `receive` to consume, `stm manage queue` to remove); Queue endpoints only (no topic endpoints); no topic subscriptions and no `--create-if-missing`.
+
+Browsing is stateless: each new session re-binds and starts again at the current head (the oldest message still spooled), with no persisted cursor.
+
 <details>
 <summary>Basic Parameters: <i><b>stm browse -h</b></i> </summary>
 
@@ -303,6 +321,11 @@ Options:
 </details>
 
 ## Send Request Events
+
+The `request` command sends a request message to a topic and waits for a reply, implementing the request-reply pattern. Use `--timeout` to bound how long it waits for each response, and `--count`/`--interval` to send more than one.
+
+- **Supported:** `DIRECT` or `PERSISTENT` delivery, per-message TTL and DMQ eligibility, application message id/type, correlation id, reply-to topic, user properties, and HTTP content-type/encoding; `TEXT` or `BYTES` payloads.
+- **Not supported:** a matching responder must be running (for example `stm reply`); if no reply arrives within `--timeout` the request fails.
 
 <details>
 <summary>Basic Parameters: <i><b>stm request -h</b></i> </summary>
@@ -410,6 +433,11 @@ Options:
 
 ## Receive Reply Events
 
+The `reply` command is the responder side of request-reply: it subscribes to one or more request topics and automatically returns a reply message for each request it receives. It runs until interrupted with Ctrl-C.
+
+- **Supported:** topic subscriptions (`-t`, including wildcards); a configurable reply body (`-m`, `-f`, `--stdin`, default, or empty); `DIRECT` or `PERSISTENT` delivery, TTL and DMQ eligibility, application message id/type, reply-to topic, user properties, and HTTP content-type/encoding.
+- **Not supported:** it only responds to requests it is subscribed for; it does not originate requests (use `request`) or browse queues.
+
 <details>
 <summary>Basic Parameters: <i><b>stm reply -h</b></i> </summary>
 
@@ -511,6 +539,8 @@ Options:
 
 ## Manage Broker Connection
 
+The `manage connection` command manages the messaging (SMF over WebSocket) connection settings - broker URL, message VPN, and credentials - used by the messaging commands, and persists them in the configuration file.
+
 <details>
 <summary>Basic Parameters: <i><b>stm manage connection -h</b></i> </summary>
 
@@ -569,6 +599,8 @@ Options:
 
 ## Manage Broker SEMP Connection
 
+The `manage semp-connection` command manages the SEMP (broker management API) connection settings - SEMP URL, VPN, and admin credentials - used by the `manage` resource commands, and persists them in the configuration file.
+
 <details>
 <summary>Basic Parameters: <i><b>stm manage semp-connection -h</b></i> </summary>
 
@@ -626,6 +658,11 @@ Options:
 </details>
 
 ## Manage Queue
+
+The `manage queue` command administers queue endpoints over SEMP. Use `--list`, `--create`, `--update`, or `--delete` to operate on a queue, along with its topic subscriptions and settings (access type, partitions, DMQ, redelivery, quotas, permissions, and more).
+
+- **Requires** a SEMP connection (admin credentials), not just a messaging connection.
+- **Related:** use `browse` to inspect messages on a queue non-destructively, and `receive` to consume them.
 
 <details>
 <summary>Basic Parameters: <i><b>stm manage queue -h</b></i> </summary>
@@ -707,6 +744,8 @@ Options:
 
 ## Manage Client Profile
 
+The `manage client-profile` command administers client profiles over SEMP with `--list`, `--create`, `--update`, and `--delete`, including guaranteed-messaging, connection, and subscription limits. Requires a SEMP connection.
+
 <details>
 <summary>Basic Parameters: <i><b>stm manage client-profile -h</b></i> </summary>
 
@@ -777,6 +816,8 @@ Options:
 
 ## Manage ACL Profile
 
+The `manage acl-profile` command administers ACL profiles over SEMP with `--list`, `--create`, `--update`, and `--delete`, including the default publish, subscribe, and connect actions. Requires a SEMP connection.
+
 <details>
 <summary>Basic Parameters: <i><b>stm manage acl-profile -h</b></i> </summary>
 
@@ -838,6 +879,8 @@ Options:
 </details>
 
 ## Manage Client Username
+
+The `manage client-username` command administers client usernames over SEMP with `--list`, `--create`, `--update`, and `--delete`, associating each with a client profile and an ACL profile. Requires a SEMP connection.
 
 <details>
 <summary>Basic Parameters: <i><b>stm manage client-username -h</b></i> </summary>
@@ -901,6 +944,8 @@ Options:
 </details>
 
 # Manage CLI Configuration Commands
+
+These commands manage the CLI configuration file that stores reusable command settings. `config init` seeds a new configuration with default command samples, `config list` shows the stored command settings (optionally filtered by `--name`), and `config delete` removes a named command setting.
 
 <details>
 <summary>Initialize Configuration: <i><b>stm config init -h</b></i> </summary>

--- a/src/common/feed-publish-client.ts
+++ b/src/common/feed-publish-client.ts
@@ -66,7 +66,7 @@ export class SolaceClient extends VisualizeClient {
   async connect() {
     return new Promise<void>((resolve, reject) => {
       if (this.session !== null) {
-        Logger.logWarn("already connected and ready to subscribe");
+        Logger.logWarn("already connected and ready to publish events");
         resolve();
         return;
       }

--- a/src/common/feed-publish-client.ts
+++ b/src/common/feed-publish-client.ts
@@ -164,7 +164,9 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        if (this.session !== null) { this.session.dispose(); this.session = null; }
         reject(error);
+        return;
       }
     });
   }

--- a/src/common/feed-publish-client.ts
+++ b/src/common/feed-publish-client.ts
@@ -67,6 +67,7 @@ export class SolaceClient extends VisualizeClient {
     return new Promise<void>((resolve, reject) => {
       if (this.session !== null) {
         Logger.logWarn("already connected and ready to subscribe");
+        resolve();
         return;
       }
       // if there's no session, create one with the properties imported from the game-config file
@@ -113,8 +114,8 @@ export class SolaceClient extends VisualizeClient {
 
         //The CONNECT_FAILED_ERROR implies a connection failure
         this.session.on(solace.SessionEventCode.CONNECT_FAILED_ERROR, (sessionEvent: solace.SessionEvent) => {
-          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} -`, `check the connection parameters!`),
-          reject();
+          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} -`, `check the connection parameters!`)
+          reject(sessionEvent);
         });
         
         //The RECONNECTING_NOTICE implies a reconnect action
@@ -151,6 +152,8 @@ export class SolaceClient extends VisualizeClient {
       } catch (error: any) {
         Logger.logDetailedError('session creation failed - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
+        return;
       }
 
       // connect the session
@@ -161,6 +164,7 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
       }
     });
   }

--- a/src/common/publish-client.ts
+++ b/src/common/publish-client.ts
@@ -165,7 +165,9 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        if (this.session !== null) { this.session.dispose(); this.session = null; }
         reject(error);
+        return;
       }
     });
   }

--- a/src/common/publish-client.ts
+++ b/src/common/publish-client.ts
@@ -68,6 +68,7 @@ export class SolaceClient extends VisualizeClient {
     return new Promise<void>((resolve, reject) => {
       if (this.session !== null) {
         Logger.logWarn("already connected and ready to subscribe");
+        resolve();
         return;
       }
       // if there's no session, create one with the properties imported from the game-config file
@@ -114,8 +115,8 @@ export class SolaceClient extends VisualizeClient {
 
         //The CONNECT_FAILED_ERROR implies a connection failure
         this.session.on(solace.SessionEventCode.CONNECT_FAILED_ERROR, (sessionEvent: solace.SessionEvent) => {
-          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} -`, `check the connection parameters!`),
-          reject();
+          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} -`, `check the connection parameters!`)
+          reject(sessionEvent);
         });
         
         //The RECONNECTING_NOTICE implies a reconnect action
@@ -152,6 +153,8 @@ export class SolaceClient extends VisualizeClient {
       } catch (error: any) {
         Logger.logDetailedError('session creation failed - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
+        return;
       }
 
       // connect the session
@@ -162,6 +165,7 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
       }
     });
   }

--- a/src/common/publish-client.ts
+++ b/src/common/publish-client.ts
@@ -67,7 +67,7 @@ export class SolaceClient extends VisualizeClient {
   async connect() {
     return new Promise<void>((resolve, reject) => {
       if (this.session !== null) {
-        Logger.logWarn("already connected and ready to subscribe");
+        Logger.logWarn("already connected and ready to publish events");
         resolve();
         return;
       }

--- a/src/common/receive-client.ts
+++ b/src/common/receive-client.ts
@@ -61,6 +61,7 @@ export class SolaceClient extends VisualizeClient {
     return new Promise<void>((resolve, reject) => {
       if (this.session !== null) {
         Logger.logWarn("already connected and ready to subscribe");
+        resolve();
         return;
       }
       // if there's no session, create one with the properties imported from the game-config file
@@ -100,8 +101,8 @@ export class SolaceClient extends VisualizeClient {
 
         //The CONNECT_FAILED_ERROR implies a connection failure
         this.session.on(solace.SessionEventCode.CONNECT_FAILED_ERROR, (sessionEvent: solace.SessionEvent) => {
-          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} - `, `check the connection parameters!`),
-          reject();
+          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} - `, `check the connection parameters!`)
+          reject(sessionEvent);
         });
 
         //DISCONNECTED implies the client was disconnected
@@ -191,6 +192,8 @@ export class SolaceClient extends VisualizeClient {
       } catch (error: any) {
         Logger.logDetailedError('session creation failed - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
+        return;
       }
 
       // connect the session
@@ -201,6 +204,7 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
       }
     });
   }

--- a/src/common/receive-client.ts
+++ b/src/common/receive-client.ts
@@ -204,7 +204,9 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        if (this.session !== null) { this.session.dispose(); this.session = null; }
         reject(error);
+        return;
       }
     });
   }

--- a/src/common/reply-client.ts
+++ b/src/common/reply-client.ts
@@ -51,6 +51,7 @@ export class SolaceClient extends VisualizeClient {
     return new Promise<void>((resolve, reject) => {
       if (this.session !== null) {
         Logger.logWarn('already connected and ready to receive requests.');
+        resolve();
         return;
       }
 
@@ -86,8 +87,8 @@ export class SolaceClient extends VisualizeClient {
           resolve();
         });
         this.session.on(solace.SessionEventCode.CONNECT_FAILED_ERROR, (sessionEvent: solace.SessionEvent) => {
-          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} - `, `check the connection parameters!`),
-          reject();
+          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} - `, `check the connection parameters!`)
+          reject(sessionEvent);
         });
         this.session.on(solace.SessionEventCode.DISCONNECTED, (sessionEvent: solace.SessionEvent) => {
           Logger.logSuccess('disconnected.');
@@ -128,6 +129,8 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('session creation failed - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
+        return;
       }
 
       // connect the session
@@ -138,6 +141,7 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
       }
     });
   }

--- a/src/common/reply-client.ts
+++ b/src/common/reply-client.ts
@@ -141,7 +141,9 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        if (this.session !== null) { this.session.dispose(); this.session = null; }
         reject(error);
+        return;
       }
     });
   }

--- a/src/common/request-client.ts
+++ b/src/common/request-client.ts
@@ -50,6 +50,7 @@ export class SolaceClient extends VisualizeClient {
     return new Promise<void>((resolve, reject) => {
       if (this.session !== null) {
         Logger.logWarn("already connected and ready to send requests");
+        resolve();
         return;
       }
 
@@ -85,8 +86,8 @@ export class SolaceClient extends VisualizeClient {
           resolve();
         });
         this.session.on(solace.SessionEventCode.CONNECT_FAILED_ERROR, (sessionEvent: solace.SessionEvent) => {
-          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} - `, `check the connection parameters!`),
-          reject();
+          Logger.logDetailedError(`connection failed to the message router ${sessionEvent.infoStr} - `, `check the connection parameters!`)
+          reject(sessionEvent);
         });
         this.session.on(solace.SessionEventCode.DISCONNECTED, (sessionEvent: solace.SessionEvent) => {
           Logger.logSuccess('disconnected.');
@@ -99,6 +100,8 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('session creation failed - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
+        return;
       }
 
       // connect the session
@@ -109,6 +112,7 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        reject(error);
       }
 
     });

--- a/src/common/request-client.ts
+++ b/src/common/request-client.ts
@@ -112,7 +112,9 @@ export class SolaceClient extends VisualizeClient {
       } catch (error:any) {
         Logger.logDetailedError('failed to connect to broker - ', error.toString())
         if (error.cause?.message) Logger.logDetailedError(``, `${error.cause?.message}`)
+        if (this.session !== null) { this.session.dispose(); this.session = null; }
         reject(error);
+        return;
       }
 
     });


### PR DESCRIPTION
Settle connect() on all paths in the messaging clients (resolve the already-connected guard, reject on createSession/connect throw, add context on CONNECT_FAILED_ERROR). Restructure the README "Run stm tool" section, add request/reply examples and a browse prerequisite, and add per-command overviews plus browse supported/not-supported notes.