### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solace-community/stm",
-  "version": "0.0.84",
+  "version": "1.0.0",
   "description": "Solace Try-Me Command Line Tool",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps the package version from 0.0.84 to 1.0.0.

`package.json` is the single source of truth for the version - `src/index.ts` imports it directly, so the CLI banner, `-v/--version`, and the update check all pick this up with no other edits needed.