### PR TITLE
DATAGO-142436: onboard FOSSA SCA scanning + manifest updates

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,25 @@
+version: 3
+
+project:
+  locator: SolaceLabs_solace-tryme-cli
+  id: SolaceLabs_solace-tryme-cli
+  name: solace-tryme-cli
+  teams: []
+  labels:
+    - typescript
+
+vendoredDependencies:
+  forceRescans: false
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - "./.git"
+      - "./.github"
+
+paths:
+  exclude:
+    - ./.git
+    - ./.github
+
+telemetry:
+  scope: full

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -1,0 +1,8 @@
+{
+  "sca_scanning": {
+    "fossa": {
+      "policy": { "mode": "REPORT" },
+      "vulnerability": { "mode": "REPORT" }
+    }
+  }
+}

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -1,0 +1,51 @@
+name: SCA Scan on merge to main
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+  actions: read
+  statuses: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  sca_scan:
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+  update_manifest:
+    needs: sca_scan
+    if: needs.sca_scan.result == 'success' && github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+          aws-region: us-east-1
+
+      - name: Update solace-cloud-manifest
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: add_item_from_json_to_dynamodb_table
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_sort_key: repository
+          ddb_item_to_be_added: |
+            {
+              "squad": "ebp",
+              "repository": "${{ github.event.repository.name }}",
+              "dev": {
+                "sha": "${{ github.sha }}",
+                "version": "${{ github.ref_name }}"
+              }
+            }

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -42,7 +42,7 @@ jobs:
           ddb_sort_key: repository
           ddb_item_to_be_added: |
             {
-              "squad": "ebp",
+              "squad": "temp",
               "repository": "${{ github.event.repository.name }}",
               "dev": {
                 "sha": "${{ github.sha }}",

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist
 
 # config json fils
 *.json
+!.github/*.json
 
 # test scripts
 config


### PR DESCRIPTION
## Summary
- Adds `.fossa.yml` with `SolaceLabs_<repo>` locator for consistent FOSSA project identification.
- Adds `.github/workflow-config.json` with both licensing and vulnerability gates in **REPORT** mode.
- Adds `.github/workflows/sca-scan-and-guard.yml` — triggers on push to \`main\`, runs FOSSA scan via the \`SolaceDev/solace-public-workflows\` reusable workflow, then updates the \`solace-cloud-manifest\` DynamoDB \`dev\` entry (squad: \`ebp\`).

Jira: [DATAGO-142436](https://sol-jira.atlassian.net/browse/DATAGO-142436)

## Test plan
- [ ] Verify workflow runs on merge to \`main\`
- [ ] Confirm FOSSA project is populated with a scan
- [ ] Confirm \`solace-cloud-manifest\` DynamoDB \`dev\` entry is updated
- [ ] Flip gates to BLOCK once REPORT mode is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DATAGO-142436]: https://sol-jira.atlassian.net/browse/DATAGO-142436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ