### PR TITLE
Restore native Apple Silicon (arm64) macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,17 +39,19 @@ jobs:
       - name: Prepare stm archives for different targets
         run: |
           cd release
-          zip -qq -r stm-macos-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos
+          zip -qq -r stm-macos-x64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos-x64
+          zip -qq -r stm-macos-arm64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos-arm64
           zip -qq -r stm-linux-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-linux
           zip -qq -r stm-alpine-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-alpine
           zip -qq -r stm-win-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-win.exe
           cd ..
-      
+
       - name: Publish artifacts to github
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            release/stm-macos-v${{ steps.package-version.outputs.current-version}}.zip
+            release/stm-macos-x64-v${{ steps.package-version.outputs.current-version}}.zip
+            release/stm-macos-arm64-v${{ steps.package-version.outputs.current-version}}.zip
             release/stm-linux-v${{ steps.package-version.outputs.current-version}}.zip
             release/stm-alpine-v${{ steps.package-version.outputs.current-version}}.zip
             release/stm-win-v${{ steps.package-version.outputs.current-version}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
           cd release
           zip -qq -r stm-macos-x64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos-x64
           zip -qq -r stm-macos-arm64-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-macos-arm64
-          zip -qq -r stm-linux-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-linux
-          zip -qq -r stm-alpine-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-alpine
-          zip -qq -r stm-win-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-win.exe
+          zip -qq -r stm-linux-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-linux-x64
+          zip -qq -r stm-alpine-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-alpine-x64
+          zip -qq -r stm-win-v${{ steps.package-version.outputs.current-version}}.zip . -i stm-win-x64.exe
           cd ..
 
       - name: Publish artifacts to github
@@ -66,7 +66,7 @@ jobs:
           mkdir -p stm-linux_${{ steps.package-version.outputs.current-version}}_amd64
           cd stm-linux_${{ steps.package-version.outputs.current-version}}_amd64
           mkdir -p usr/bin
-          cp ../release/stm-linux usr/bin/stm
+          cp ../release/stm-linux-x64 usr/bin/stm
           mkdir -p DEBIAN
           echo "Package: stm
           Version: ${{ steps.package-version.outputs.current-version}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solace-community/stm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Solace Try-Me Command Line Tool",
   "repository": {
     "type": "git",
@@ -87,6 +87,7 @@
     "targets": [
       "node18-linux-x64",
       "node18-macos-x64",
+      "node18-macos-arm64",
       "node18-win-x64",
       "node18-alpine-x64"
     ],

--- a/scripts/update_homebrew.sh
+++ b/scripts/update_homebrew.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Define variables
 REPO_NAME="SolaceLabs/solace-tryme-cli"
@@ -17,9 +17,18 @@ git clone https://x-access-token:$GITHUB_TOKEN@github.com/$TAP_NAME
 
 cd homebrew-$FORMULA_NAME
 
+X64_ZIP=../release/stm-macos-x64-v$pkg_version.zip
+ARM64_ZIP=../release/stm-macos-arm64-v$pkg_version.zip
+for f in "$X64_ZIP" "$ARM64_ZIP"; do
+  if [ ! -f "$f" ]; then
+    echo "Release artifact not found: $f" >&2
+    exit 1
+  fi
+done
+
 # Calculate SHA256 for both macOS archs
-SHA256_X64=$(shasum -a 256 ../release/stm-macos-x64-v$pkg_version.zip | awk '{ print $1 }')
-SHA256_ARM64=$(shasum -a 256 ../release/stm-macos-arm64-v$pkg_version.zip | awk '{ print $1 }')
+SHA256_X64=$(shasum -a 256 "$X64_ZIP" | awk '{ print $1 }')
+SHA256_ARM64=$(shasum -a 256 "$ARM64_ZIP" | awk '{ print $1 }')
 
 # Regenerate the formula from scratch (idempotent, no reliance on prior file structure)
 cat > Formula/$FORMULA_NAME.rb <<EOF

--- a/scripts/update_homebrew.sh
+++ b/scripts/update_homebrew.sh
@@ -6,19 +6,60 @@ REPO_NAME="SolaceLabs/solace-tryme-cli"
 TAP_NAME="SolaceLabs/homebrew-stm.git"
 FORMULA_NAME="stm"
 
+pkg_version=$1
+if [ -z "$pkg_version" ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
 # Clone the Homebrew tap
 git clone https://x-access-token:$GITHUB_TOKEN@github.com/$TAP_NAME
 
 cd homebrew-$FORMULA_NAME
 
-# Update formula
-pkg_version=$1
-sed -i "s|url .*|url \"https://github.com/$REPO_NAME/releases/download/v$pkg_version/stm-macos-v$pkg_version.zip\"|" Formula/$FORMULA_NAME.rb
-sed -i "s|sha256 .*|sha256 \"$(shasum -a 256 ../release/stm-macos-v$pkg_version.zip | awk '{ print $1 }')\"|" Formula/$FORMULA_NAME.rb
+# Calculate SHA256 for both macOS archs
+SHA256_X64=$(shasum -a 256 ../release/stm-macos-x64-v$pkg_version.zip | awk '{ print $1 }')
+SHA256_ARM64=$(shasum -a 256 ../release/stm-macos-arm64-v$pkg_version.zip | awk '{ print $1 }')
+
+# Regenerate the formula from scratch (idempotent, no reliance on prior file structure)
+cat > Formula/$FORMULA_NAME.rb <<EOF
+class Stm < Formula
+  desc "This is a command line tool to help you get started with Solace PubSub+ Event Broker"
+  homepage "https://github.com/$REPO_NAME"
+  version "$pkg_version"
+  license "Apache-2.0"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/$REPO_NAME/releases/download/v$pkg_version/stm-macos-x64-v$pkg_version.zip"
+      sha256 "$SHA256_X64"
+
+      def install
+        bin.install "stm-macos-x64" => "stm"
+      end
+    end
+
+    on_arm do
+      url "https://github.com/$REPO_NAME/releases/download/v$pkg_version/stm-macos-arm64-v$pkg_version.zip"
+      sha256 "$SHA256_ARM64"
+
+      def install
+        bin.install "stm-macos-arm64" => "stm"
+      end
+    end
+  end
+
+  test do
+    system "#{bin}/stm", "--version"
+  end
+end
+EOF
+
 # Commit and push changes
 git config --global user.email "community@solace.com"
 git config --global user.name "SollyBot"
-git commit -am "Update $FORMULA_NAME to $pkg_version"
+git add Formula/$FORMULA_NAME.rb
+git commit -m "Update $FORMULA_NAME to $pkg_version" --allow-empty
 git push
 
 cd ..


### PR DESCRIPTION
## Summary
- Re-adds `node18-macos-arm64` to `pkg.targets` in `package.json` (removed in #77 to unblock the release pipeline)
- Splits `release.yml`'s macOS zip/publish step into separate `stm-macos-x64` / `stm-macos-arm64` archives, matching the naming PR #69 originally introduced
- Rewrites `scripts/update_homebrew.sh` to regenerate `Formula/stm.rb` from scratch each release with real `on_intel`/`on_arm` blocks, instead of `sed`-patching a formula structure that never actually existed live — this was the root cause of Homebrew always installing the x64 binary under Rosetta on Apple Silicon, and the reason #69's arm64 support got reverted in #77
- Bumps version to `1.0.1`

## Test plan
- [x] `bash -n scripts/update_homebrew.sh` — syntax OK
- [x] Dry-ran the updated Homebrew script against a scratch local tap clone (no network/real repo touched) — confirmed it generates a valid `on_macos`/`on_intel`/`on_arm` formula with correct URLs, per-arch sha256, and per-arch `install` blocks
- [x] `ruby -c` on the generated formula — syntax OK
- [ ] After merge, cut `v1.0.1` and confirm the release workflow succeeds end-to-end (build, package, publish both macOS zips, Homebrew formula update)
- [ ] On an Apple Silicon Mac: `brew install stm` (or `brew upgrade`), then `file "$(which stm)"` — expect `Mach-O 64-bit executable arm64`, not `x86_64`
- [ ] Confirm Intel path (`on_intel`) still installs and runs correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)