### PR TITLE
Fix generateSendTimestamps and generateReceiveTimestamps from config

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,7 +4,7 @@ import http from 'http'
 import path from 'path'
 import { Logger } from './logger'
 import chalk from 'chalk'
-import { baseCommands, commandConnection, commandSempConnection, defaultConfigFile, defaultLastVersionCheck, defaultManageConnectionConfig, defaultFakerRulesFile, defaultFeedAnalysisFile, defaultFeedInfoFile, defaultFeedRulesFile, defaultFeedSchemasFile, defaultGitRepo, defaultMessageConnectionConfig, defaultMetaKeys, getCommandGroup, getDefaultConfig, defaultStmHome, defaultStmFeedsHome, defaultFeedApiEndpointFile, defaultFeedSessionFile } from './defaults'
+import { baseCommands, commandConnection, commandSempConnection, connectionConfigToOptionKey, defaultConfigFile, defaultLastVersionCheck, defaultManageConnectionConfig, defaultFakerRulesFile, defaultFeedAnalysisFile, defaultFeedInfoFile, defaultFeedRulesFile, defaultFeedSchemasFile, defaultGitRepo, defaultMessageConnectionConfig, defaultMetaKeys, getCommandGroup, getDefaultConfig, defaultStmHome, defaultStmFeedsHome, defaultFeedApiEndpointFile, defaultFeedSessionFile } from './defaults'
 import { buildMessageConfig } from './init'
 import { parseNumber } from './parse'
 import { fakerRulesJson } from './fakerrules';
@@ -330,6 +330,22 @@ const healMissingBaseCommand = (config: any, filePath: string, group: string, cm
   return true;
 }
 
+// Copy the connection settings out of a loaded configuration onto the options object.
+// Settings that the CLI exposes under a different name are also copied across under the
+// option name, so that the config -> options merge in index.ts (which matches on option
+// name) picks them up instead of dropping them.
+const applyConnectionSettings = (configOptions: any, config: any, group: string) => {
+  const connectionKeys = Object.keys(group === 'manage' ? defaultManageConnectionConfig : defaultMessageConnectionConfig);
+  const connection = config[group][group === 'manage' ? 'sempconnection' : 'connection'];
+  for (var i=0; i<connectionKeys.length; i++) {
+    const key = connectionKeys[i];
+    configOptions[key] = connection[key];
+    const optionKey = connectionConfigToOptionKey[key];
+    if (optionKey) configOptions[optionKey] = connection[key];
+  }
+  return configOptions
+}
+
 export const loadCommandFromConfig = (cmd: string, options: MessageClientOptions | ManageClientOptions | ManageFeedPublishOptions) => {
   try {
     var group = getCommandGroup(cmd)
@@ -362,11 +378,7 @@ export const loadCommandFromConfig = (cmd: string, options: MessageClientOptions
       }
       // TODO: validateConfig(config)
 
-      const configOptions:any = {}
-      const connectionKeys = Object.keys(group === 'manage' ? defaultManageConnectionConfig : defaultMessageConnectionConfig);
-      for (var i=0; i<connectionKeys.length; i++) {
-        configOptions[connectionKeys[i]] = config[group][group === 'manage' ? 'sempconnection' : 'connection'][connectionKeys[i]];
-      }
+      const configOptions:any = applyConnectionSettings({}, config, group)
       const defaultConfig = getDefaultConfig(cmd);
       const clientKeys = Object.keys(defaultConfig);
       for (var i=0; i<clientKeys.length; i++) {
@@ -390,11 +402,7 @@ export const loadCommandFromConfig = (cmd: string, options: MessageClientOptions
       }
       // TODO: validateConfig(config)
 
-      const configOptions:any = {}
-      const connectionKeys = Object.keys(group === 'manage' ? defaultManageConnectionConfig : defaultMessageConnectionConfig);
-      for (var i=0; i<connectionKeys.length; i++) {
-        configOptions[connectionKeys[i]] = config[group][group === 'manage' ? 'sempconnection' : 'connection'][connectionKeys[i]];
-      }
+      const configOptions:any = applyConnectionSettings({}, config, group)
       const defaultConfig = getDefaultConfig(cmd);
       const clientKeys = Object.keys(defaultConfig);
       for (var i=0; i<clientKeys.length; i++) {
@@ -413,11 +421,7 @@ export const loadCommandFromConfig = (cmd: string, options: MessageClientOptions
         if (!filePath.endsWith('.json')) filePath.concat('.json')
 
         const config = readFile(filePath)
-        const configOptions:any = {}
-        const connectionKeys = Object.keys(group === 'manage' ? defaultManageConnectionConfig : defaultMessageConnectionConfig);
-        for (var i=0; i<connectionKeys.length; i++) {
-          configOptions[connectionKeys[i]] = config[group][group === 'manage' ? 'sempconnection' : 'connection'][connectionKeys[i]];
-        }
+        const configOptions:any = applyConnectionSettings({}, config, group)
         const defaultConfig = getDefaultConfig(cmd);
         const clientKeys = Object.keys(defaultConfig);
         for (var i=0; i<clientKeys.length; i++) {

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -123,6 +123,17 @@ export const defaultMessageConnectionConfig:any = {
   save: false,
 }
 
+// A few connection settings are stored in the configuration file under the solclientjs
+// session property name, while the CLI exposes them under a shorter option name (for
+// example 'generateSendTimestamps' vs '--send-timestamps'). Without this mapping the
+// settings are silently dropped when a command is loaded from - or saved to - a
+// configuration, since both directions match on key name alone.
+// Keyed by configuration key, valued by the camelCased CLI option name.
+export const connectionConfigToOptionKey:any = {
+  generateSendTimestamps: 'sendTimestamps',
+  generateReceiveTimestamps: 'receiveTimestamps',
+}
+
 export const defaultMessageConfig:any = {
   // acknowledgeImmediately: false,
   appMessageId: undefined,

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -18,7 +18,8 @@ import {
   commandConnection,
   commandSempConnection,
   manageCommands,
-  defaultStmHome
+  defaultStmHome,
+  connectionConfigToOptionKey
 } from './defaults'
 import { saveConfig, loadConfig, decoratePath, processPath, fileExists, writeConfig } from './config'
 import chalk from 'chalk'
@@ -288,8 +289,10 @@ export const buildMessageConfig = (current: any, options:any, optionsSource: any
 
   // initialize messaging settings
   result.message.connection && Object.keys(defaultMessageConnectionConfig).forEach((key:string) => {
-    if (optionsSource[key] === 'cli') {
-      result.message.connection[key] = options[key];
+    // a few settings are carried on the options object under their CLI option name
+    const optionKey = connectionConfigToOptionKey[key] ? connectionConfigToOptionKey[key] : key;
+    if (optionsSource[optionKey] === 'cli') {
+      result.message.connection[key] = options[optionKey];
     } else {
       current ? 
         result.message.connection[key] = current.message.connection[key] :


### PR DESCRIPTION
The config file stores these under the solclientjs session property names (generateSendTimestamps, generateReceiveTimestamps) while the CLI exposes them as --send-timestamps and --receive-timestamps. Both the config -> options merge in index.ts and the options -> config save in buildMessageConfig match purely on key name, so the values were silently dropped in both directions. Setting them in the config had no effect; only the CLI flags worked, and --send-timestamps --save never persisted.

Adds connectionConfigToOptionKey mapping the config keys to their option names, applies it when loading a command from a configuration, and resolves the option name when writing settings back.